### PR TITLE
Load text domain from relative path

### DIFF
--- a/includes/functions.php
+++ b/includes/functions.php
@@ -38,7 +38,7 @@ function _cme_taxonomy_late_reg( $taxonomy, $tx_obj ) {
 function _cme_init() {
 	require_once ( dirname(__FILE__) . '/filters.php' );
 
-	load_plugin_textdomain('capsman-enhanced', false, dirname(__FILE__) . '/lang');
+	load_plugin_textdomain('capsman-enhanced', false, dirname(plugin_basename(__FILE__)) . '/lang');
 }
 
 function cme_is_plugin_active($check_plugin_file) {


### PR DESCRIPTION
## Description
Resolves #50 by wrapping __FILE__ with `plugin_basename(__FILE__)`

## Benefits
Language files can be loaded without causing an error

## Possible drawbacks
If the relative path is not calculated correctly, the language files will still not load.

## Applicable issues
#50 "Loading language files throws an error when open_basedir is enabled"

