### PR TITLE
Multisite: improper handling of non-standard main site ID

### DIFF
--- a/includes/admin.php
+++ b/includes/admin.php
@@ -1193,8 +1193,9 @@ if( defined('PRESSPERMIT_ACTIVE') ) {
 
 <?php
 function cme_network_role_ui( $default ) {
-	if ( ! is_multisite() || ! is_super_admin() || ( 1 != get_current_blog_id() ) )
+	if (!is_multisite() || !is_super_admin() || !is_main_site()) {
 		return false;
+	}
 	?>
 
 	<div style="float:right;margin-left:10px;margin-right:10px">

--- a/includes/handler.php
+++ b/includes/handler.php
@@ -257,7 +257,7 @@ class CapsmanHandler
 		
 		$this->cm->log_db_roles();
 		
-		if ( is_multisite() && is_super_admin() && ( 1 == get_current_blog_id() ) ) {
+		if (is_multisite() && is_super_admin() && is_main_site()) {
 			if ( ! $autocreate_roles = get_site_option( 'cme_autocreate_roles' ) )
 				$autocreate_roles = array();
 			


### PR DESCRIPTION
Network-activated plugin did not display menu item if main site ID is not 1

Fixes #63