### PR TITLE
More improvements to Restore & Backup UI

### DIFF
--- a/admin.css
+++ b/admin.css
@@ -214,9 +214,49 @@ table#akmin td.sidebar li.publishpress-contact a{padding:5px 0 5px 0;}
 #pp_features ul.pp-features li:before { content: "\2713\0020"; }
 #pp_features ul.pp-features li { padding-bottom: 5px }
 #pp_features img.cme-play { margin-bottom: -3px; margin-left: 5px;}
+
 div.publishpress-caps-manage span.manage-members {margin-left:5px; font-weight:normal; color: #777}
 div.publishpress-caps-manage span.manage-members a {color: #777}
 div.publishpress-caps-manage span.manage-members a:hover {text-decoration: underline; color:#655997 }
 
 div.publishpress-headline .cme-subtext a {font-weight: bold}
 div.publishpress-headline .cme-subtext a:hover {text-decoration: underline}
+
+div.publishpress-caps-backup th {text-align:right; padding-top:28px; width: 140px}
+div.publishpress-caps-backup p.description {max-width:620px !important;}
+
+div.publishpress-caps-backup #cme_select_restore_div {height:250px;}
+div.publishpress-caps-backup #cme_select_restore {
+list-style:none;
+max-height:250px;
+margin:0;
+overflow:auto;
+padding:0;
+background-color: #eee;
+padding: 5px;
+width: min-content;
+text-indent:10px;
+}
+div.publishpress-caps-backup #cme_select_restore li {
+padding: 7px 15px 7px 7px;
+white-space: nowrap;
+background-color: #f4f4f4;
+margin: 0;
+line-height:25px;
+}
+
+div.publishpress-caps-backup #cme_select_restore li label {
+font-size: 13px;
+}
+
+div.publishpress-caps-backup #cme_select_restore li:nth-child(even){background-color:white;}
+
+div.cme-selected-backup-caption {padding-left: 5px;}
+div.cme-restore-button {margin-top: 25px; padding-left: 5px}
+
+div.publishpress-caps-backup td.cme-backup-info{padding:0}
+div.publishpress-caps-backup td.cme-backup-info li {display:none;}
+div.publishpress-caps-backup td.cme-backup-info li.cme-change {display: list-item;}
+
+div.publishpress-caps-backup td.cme-backup-info .cme-plus {font-weight: bold; color: green}
+div.publishpress-caps-backup td.cme-backup-info .cme-minus {font-weight: bold; color: #a00; text-decoration: line-through;}

--- a/includes/backup.php
+++ b/includes/backup.php
@@ -34,7 +34,7 @@ global $wpdb;
 $auto_backups = $wpdb->get_results("SELECT option_name, option_value FROM $wpdb->options WHERE option_name LIKE 'cme_backup_auto_%' ORDER BY option_id DESC");
 ?>
 
-<div class="wrap publishpress-caps-manage pressshack-admin-wrapper">
+<div class="wrap publishpress-caps-manage publishpress-caps-backup pressshack-admin-wrapper">
     <div id="icon-capsman-admin" class="icon32"></div>
     <h2><?php printf(__('Backup Tool for %1$sPublishPress Capabilities%2$s', 'capsman-enhanced'), '<a href="admin.php?page=capsman">', '</a>'); ?></h2>
 
@@ -43,8 +43,8 @@ $auto_backups = $wpdb->get_results("SELECT option_name, option_value FROM $wpdb-
         <?php wp_nonce_field('capsman-backup-tool'); ?>
 
         <ul id="publishpress-capability-backup-tabs" class="nav-tab-wrapper">
-            <li class="nav-tab nav-tab-active"><a href="#ppcb-tab-backup">Backup</a></li>
-            <li class="nav-tab"><a href="#ppcb-tab-restore">Restore</a></li>
+            <li class="nav-tab nav-tab-active"><a href="#ppcb-tab-restore">Restore</a></li>
+            <li class="nav-tab"><a href="#ppcb-tab-backup">Backup</a></li>
             <li class="nav-tab"><a href="#ppcb-tab-reset">Reset Roles</a></li>
         </ul>
 
@@ -53,81 +53,131 @@ $auto_backups = $wpdb->get_results("SELECT option_name, option_value FROM $wpdb-
                 <tr>
                     <td class="content">
 
-
-                        <dl id="ppcb-tab-backup">
-                            <dt><?php _e('Backup', 'capsman-enhanced'); ?></dt>
+                        <dl id="ppcb-tab-backup" style="display:none;">
+                            <dt><?php _e('Backup Roles and Capabilities', 'capsman-enhanced'); ?></dt>
                             <dd>
-                                <table width='100%' class="form-table">
-                                    <tr>
-                                        <td>
-                                            <select id="cme_select_backup" name="select_backup">
-                                                <option value="backup"> <?php _e('Backup roles and capabilities', 'capsman-enhanced'); ?> </option>
-                                            </select> &nbsp;
-                                            <input type="submit" name="save_backup"
-                                                   value="<?php _e('Backup', 'capsman-enhanced') ?>"
-                                                   class="button-primary"/>
+                                <p class="description">
+                                <?php 
+                                $max_auto_backups = (defined('CME_AUTOBACKUPS')) ? CME_AUTOBACKUPS : 20;
+                                printf(__('PublishPress Capabilities automatically creates a backup on installation and whenever you save changes. The initial backup and last %d auto-backups are kept.', 'capsman-enhanced'), $max_auto_backups);
+                                ?>
+                                </p>
 
-                                        </td>
-                                    </tr>
-                                </table>
+                                <p class="description">
+                                <?php _e('A backup created on this screen replaces any previous manual backups, but is never automatically replaced.', 'capsman-enhanced');?>
+                                </p>
+
+                                <div style="margin-top:5px">
+                                            <input type="submit" name="save_backup"
+                                            value="<?php _e('Manual Backup', 'capsman-enhanced') ?>"
+                                                   class="button-primary"/>
+                                </div>
                             </dd>
 
                         </dl>
 
+                        <?php
+                        $listed_manual_backup = false;
+                        $backup_datestamp = get_option('capsman_backup_datestamp');
+                        $last_caption = ($backup_datestamp) ? sprintf(__('Last Manual Backup - %s', 'capsman-enhanced'), date('j M Y, g:i a', $backup_datestamp)) : __('Last Backup', 'capsman-enhanced');
+                        ?>
 
-                        <dl id="ppcb-tab-restore" style="display:none;">
-                            <dt><?php _e('Restore Backup', 'capsman-enhanced'); ?></dt>
+                        <dl id="ppcb-tab-restore">
+                            <dt><?php _e('Restore Previous Roles and Capabilities', 'capsman-enhanced'); ?></dt>
                             <dd>
+                                <p class="description">
+                                <?php _e('PublishPress Capabilities automatically creates a backup on installation and whenever you save changes.', 'capsman-enhanced');?>
+                                </p>
+
+                                <p class="description">
+                                <?php _e('On this screen, you can restore an earlier version of your roles and capabilities.', 'capsman-enhanced');?>
+                                </p>
+
                                 <table width='100%' class="form-table">
                                     <tr>
-                                        <th scope="row"><?php _e('Select action:', 'capsman-enhanced'); ?></th>
+                                        <th scope="row"><?php _e('Available Backups:', 'capsman-enhanced'); ?></th>
                                         <td>
-                                            <select id="cme_select_restore" name="select_restore">
-
-                                                <?php
-                                                if ($initial = get_option('capsman_backup_initial')):?>
-                                                    <option value="restore_initial"> <?php _e('Restore initial backup', 'capsman-enhanced'); ?> </option>
-                                                <?php endif; ?>
-
-                                                <option value="restore"> <?php _e('Restore last manually saved backup', 'capsman-enhanced'); ?> </option>
-
+                                            <div id="cme_select_restore_div">
+                                            <ul id="cme_select_restore">
                                                 <?php foreach ($auto_backups as $row):
                                                     $arr = explode('_', str_replace('cme_backup_auto_', '', $row->option_name));
                                                     $arr[1] = str_replace('-', ':', $arr[1]);
                                                     $date_caption = implode(' ', $arr);
+
+                                                    if (!$listed_manual_backup && ($backup_datestamp > strtotime($date_caption))) :
+                                                        $manual_date_caption = date('Y-m-d, g:i a', $backup_datestamp);
                                                     ?>
-                                                    <option value="<?php echo $row->option_name; ?>"><?php printf(__('Restore auto-backup (%s)', 'capsman-enhanced'), $date_caption); ?></option>
+                                                        <li>
+                                                        <input type="radio" name="select_restore" value="restore" id="cme_restore_manual">
+                                                        <label for="cme_restore_manual"><?php printf(__('Manual backup of all roles (%s)', 'capsman-enhanced'), $manual_date_caption); ?></label>
+                                                        </li>
+                                                        <?php
+                                                        $listed_manual_backup = true;
+                                                    endif;
+                                                    ?>
+
+                                                    <?php
+                                                    $date_caption = str_replace(' ', ', ', $date_caption);
+                                                    $date_caption = str_replace(', am', ' am', $date_caption);
+                                                    $date_caption = str_replace(', pm', ' pm', $date_caption);
+                                                    ?>
+
+                                                    <li>
+                                                    <input type="radio" name="select_restore" value="<?php echo $row->option_name;?>" id="<?php echo $row->option_name;?>">
+                                                    <label for="<?php echo $row->option_name;?>"><?php printf(__('Auto-backup of all roles (%s)', 'capsman-enhanced'), $date_caption); ?></label>
+                                                    </li>
                                                 <?php endforeach; ?>
-                                            </select> &nbsp;
+
+                                                <?php
+                                                if ($initial = get_option('capsman_backup_initial')):?>
+                                                    <li>
+                                                    <input type="radio" name="select_restore" value="restore_initial" id="cme_restore_initial">
+                                                    <label for="cme_restore_manual"><?php _e('Initial backup of all roles', 'capsman-enhanced'); ?></label>
+                                                    </li>
+                                                <?php endif; ?>
+                                            <!-- </select> --> 
+                                            </ul>
+                                            </div>
+
+                                            <div class="cme-restore-button">
                                             <input type="submit" name="restore_backup"
-                                                   value="<?php _e('Restore', 'capsman-enhanced') ?>"
+                                                   value="<?php _e('Restore Selected Roles', 'capsman-enhanced') ?>"
                                                    class="button-primary"/>
 
-                                            <p>&nbsp;<span class="cme-subtext">
-						<?php
-                        _e('To view the contents of a backup, select it in the dropdown above.', 'press-permit-core');
-                        ?>
-						</span></p>
+                                            <div class="cme-selected-backup-caption">
+                                            <span class="cme-selected-backup-caption cme-subtext"></span>
+                                            </div>
+                                            </div>
                                         </td>
-                                    </tr>
-                                </table>
-                            </dd>
+
+                                        <td class="cme-backup-info">
+                                            <div class="cme_backup_info_changes_only" style="display:none">
+                                            <input type="checkbox" class="cme_backup_info_changes_only" checked=checked><?php _e('Show changes from current roles only', 'capsman-enhanced');?>
+                                            </div>
 
                             <?php
                             global $wp_roles;
 
                             $initial_caption = ($backup_datestamp = get_option('capsman_backup_initial_datestamp')) ? sprintf(__('Initial Backup - %s', 'capsman-enhanced'), date('j M Y, g:i a', $backup_datestamp)) : __('Initial Backup', 'capsman-enhanced');
-                            $last_caption = ($backup_datestamp = get_option('capsman_backup_datestamp')) ? sprintf(__('Last Manual Backup - %s', 'capsman-enhanced'), date('j M Y, g:i a', $backup_datestamp)) : __('Last Backup', 'capsman-enhanced');
 
                             $backups = array(
                                 'capsman_backup_initial' => $initial_caption,
-                                'capsman_backup' => $last_caption,
                             );
+
+                                            if (!$capsman_backup) {
+                                                $backups['capsman_backup'] = $last_caption;
+                                            }
 
                             foreach ($auto_backups as $row) {
                                 $arr = explode('_', str_replace('cme_backup_auto_', '', $row->option_name));
                                 $arr[1] = str_replace('-', ':', $arr[1]);
-                                $backups[$row->option_name] = "Auto-backup from " . implode(' ', $arr);
+
+                                                $date_caption = implode(' ', $arr);
+                                                $date_caption = str_replace(' ', ', ', $date_caption);
+                                                $date_caption = str_replace(', am', ' am', $date_caption);
+                                                $date_caption = str_replace(', pm', ' pm', $date_caption);
+
+                                                $backups[$row->option_name] = "Auto-backup from " . $date_caption;
                             }
 
                             foreach ($backups as $name => $caption) {
@@ -136,7 +186,26 @@ $auto_backups = $wpdb->get_results("SELECT option_name, option_value FROM $wpdb-
                                          class="cme-show-backup">
                                         <h3><?php printf(__("%s (%s roles)", 'capsman-enhanded'), $caption, count($backup_data)); ?></h3>
 
-                                        <?php foreach ($backup_data as $role => $props) : ?>
+                                                        <?php 
+                                                        foreach (array_keys($wp_roles->role_objects) as $role) {
+                                                            if (empty($backup_data[$role])) {
+                                                                $role_caption = $props['name'];
+                                                                $role_class = ' class="cme-change cme-minus"'; 
+                                                                ?>
+                                                                <h4><span<?php echo $role_class;?>><?php echo (translate_user_role($role_caption));?></span> <?php _e('(this role will be removed if you restore backup)', 'capsman-enhanced');?></h4>
+                                                                <?php
+                                                            }
+                                                        }
+                                                        ?>
+
+                                                        <?php foreach ($backup_data as $role => $props) : 
+                                                            if (!empty($wp_roles->role_objects[$role]->capabilities)) {
+                                                                $props['capabilities'] = array_merge(
+                                                                    array_fill_keys(array_keys($wp_roles->role_objects[$role]->capabilities), false),
+                                                                    $props['capabilities']
+                                                                );
+                                                            }
+                                                        ?>
                                             <?php if (!isset($props['name'])) continue; ?>
                                             <?php
                                             $level = 0;
@@ -149,8 +218,10 @@ $auto_backups = $wpdb->get_results("SELECT option_name, option_value FROM $wpdb-
                                             ?>
                                             <?php
                                             $role_caption = $props['name'];
-                                            if (empty($wp_roles->role_objects[$role])) $role_caption = "<span class='cme-plus' style='color:green;font-weight:800'>$role_caption</span>"; ?>
-                                            <h4><?php printf(__('%s (level %s)', 'capsman-enhanced'), translate_user_role($role_caption), $level); ?></h4>
+                                                            $role_class = (empty($wp_roles->role_objects[$role])) ? ' class="cme-change cme-plus"' : ''; 
+                                                            ?>
+
+                                                            <h4<?php echo $role_class;?>><?php printf(__('%s (level %s)', 'capsman-enhanced'), translate_user_role($role_caption), $level); ?></h4>
                                             <ul style="list-style:disc;padding-left:30px">
 
                                                 <?php
@@ -158,8 +229,17 @@ $auto_backups = $wpdb->get_results("SELECT option_name, option_value FROM $wpdb-
                                                 foreach ($props['capabilities'] as $cap_name => $val) :
                                                     if (0 === strpos($cap_name, 'level_')) continue;
                                                     ?>
-                                                    <?php if ($val && (empty($wp_roles->role_objects[$role]) || empty($wp_roles->role_objects[$role]->capabilities[$cap_name]))) $cap_name = "<span class='cme-plus' style='color:green;font-weight:800'>$cap_name</span>"; ?>
-                                                    <li><?php echo ($val) ? $cap_name : "<strike>$cap_name</strike>"; ?></li>
+                                                                    <?php 
+                                                                    if ($val && (empty($wp_roles->role_objects[$role]) || empty($wp_roles->role_objects[$role]->capabilities[$cap_name]))) {
+                                                                        $class = ' class="cme-change cme-plus"';
+                                                                    } elseif (!$val) {
+                                                                        $class = ' class="cme-change cme-minus"';
+                                                                        $cap_name = "&nbsp;&nbsp;$cap_name&nbsp;&nbsp;";
+                                                                    } else {
+                                                                        $class = '';
+                                                                    }
+                                                                    ?>
+                                                                    <li<?php echo $class;?>><?php echo $cap_name;?></li>
                                                 <?php endforeach; ?>
 
                                             </ul>
@@ -168,6 +248,10 @@ $auto_backups = $wpdb->get_results("SELECT option_name, option_value FROM $wpdb-
                                 <?php endif;
                             }
                             ?>
+                                        </td>
+                                    </tr>
+                                </table>
+                            </dd>
                         </dl>
 
 
@@ -202,23 +286,35 @@ $auto_backups = $wpdb->get_results("SELECT option_name, option_value FROM $wpdb-
         /* <![CDATA[ */
         jQuery(document).ready(function ($) {
 
-            $('#cme_select_restore').on('change click', function () {
+            $('#cme_select_restore input[name="select_restore"]').on('change click', function () {
                 $('div.cme-show-backup').hide();
+
+                $('span.cme-selected-backup-caption').html($(this).next('label').html());
 
                 var selected_val = $(this).val();
 
+                $('td.cme-backup-info div').hide();
+
                 switch (selected_val) {
                     case 'restore_initial':
-                        $('#cme_display_capsman_backup_initial').show();
+                        $('#cme_display_capsman_backup_initial').addClass('current-display').show();
                         break;
                     case 'restore':
-                        $('#cme_display_capsman_backup').show();
+                        $('#cme_display_capsman_backup').addClass('current-display').show();
                         break;
                     default:
-                        $('#cme_display_' + selected_val).show();
+                        $('#cme_display_' + selected_val).addClass('current-display').show();
                 }
+
+                $('input.cme_backup_info_changes_only').click();
+                $('div.cme_backup_info_changes_only').show();
             });
 
+            $('input.cme_backup_info_changes_only').click(function() {
+                $(this).attr('disabled', true);
+                $('td.cme-backup-info div.current-display li:not(.cme-change)').toggle(!$(this).prop('checked'));
+                $(this).removeAttr('disabled');
+            });
 
             $('#publishpress-capability-backup-tabs').find('li').click(function (e) {
                 e.preventDefault();


### PR DESCRIPTION

![restore-backup-capabilities](https://user-images.githubusercontent.com/43488774/94835498-c7d2bf80-03df-11eb-93d8-f5b447b2091c.png)
Swap the tab order to Restore, Backup.

Change "Restore" dropdown to a vertical scrolling list of option buttons.

Top restore option is latest backup.

Display manual backup in chronological order alongside auto-backups.

Improve caption text.

Improve date, time formatting.

Backup info displays on the right when a restore option is clicked.

Backup info indicates roles that do not exist in backup, displays caution that restoring backup will delete the role.

Backup info defaults to displaying modified capabilities only.  Checkbox option to display all capabilities.