### PR TITLE
Type-Specific Capabilities offered for private post types

### DIFF
--- a/includes/admin.php
+++ b/includes/admin.php
@@ -217,7 +217,7 @@ if( defined('PRESSPERMIT_ACTIVE') ) {
 				$custom_tax = get_taxonomies( array( '_builtin' => false ), 'names' );
 				
 				$defined = array();
-				$defined['type'] = get_post_types( array( 'public' => true, 'show_ui' => true, 'map_meta_cap' => true ), 'object', 'or' );
+				$defined['type'] = apply_filters('cme_filterable_post_types', get_post_types( array( 'public' => true, 'show_ui' => true), 'object', 'or' ));
 				$defined['taxonomy'] = get_taxonomies( array( 'public' => true ), 'object' );
 				
 				$unfiltered['type'] = apply_filters( 'pp_unfiltered_post_types', array( 'forum','topic','reply','wp_block' ) );  // bbPress' dynamic role def requires additional code to enforce stored caps

--- a/includes/filters.php
+++ b/includes/filters.php
@@ -51,6 +51,16 @@ add_filter('pp_custom_status_list', 'cme_filter_custom_status_list', 10, 2);
 
 add_action('plugins_loaded', '_cme_migrate_pp_options');
 
+add_filter('cme_filterable_post_types', '_cme_filterable_post_types');
+
+function _cme_filterable_post_types($post_type_objects) {
+	if ($advgb_profiles = get_post_type_object('advgb_profiles')) {
+		$post_type_objects['advgb_profiles'] = $advgb_profiles;
+	}
+
+	return $post_type_objects;
+}
+
 function _cme_publishpress_roles_js() {
 	if (defined('PUBLISHPRESS_VERSION') && ((strpos($_SERVER['REQUEST_URI'], 'page=pp-manage-roles')))) {
 		require_once(dirname(__FILE__) . '/publishpress-roles.php');
@@ -233,7 +243,7 @@ function cme_get_assisted_post_types() {
 	
 	$post_types = get_post_types( $type_args, 'names', 'or' );
 	
-	if ( $omit_types = apply_filters( 'pp_unfiltered_post_types', array( 'wp_block' ) ) ) {
+	if ( $omit_types = apply_filters( 'pp_unfiltered_post_types', array('forum', 'topic', 'reply', 'wp_block', 'customize_changeset') ) ) {
 		$post_types = array_diff_key( $post_types, array_fill_keys( (array) $omit_types, true ) );
 	}
 	

--- a/includes/pp-ui.php
+++ b/includes/pp-ui.php
@@ -108,7 +108,7 @@ class Capsman_PP_UI {
 				
 				echo "<table style='width:100%'><tr>";
 				
-				$unfiltered = apply_filters( 'pp_unfiltered_post_types', array('forum','topic','reply','wp_block') );			// bbPress' dynamic role def requires additional code to enforce stored caps
+				$unfiltered = apply_filters( 'pp_unfiltered_post_types', array('forum','topic','reply','wp_block', 'customize_changeset') );			// bbPress' dynamic role def requires additional code to enforce stored caps
 				$hidden = apply_filters( 'pp_hidden_post_types', array() );
 				
 				echo '<td style="width:50%">';


### PR DESCRIPTION
Fixes #71 

Non-public post types cannot be supported by default because their capability implementation in WP core is inconsistent.  Revert to previous behavior of only offering for post types that have the public or show_ui property set true.

This also adds a 'cme_filterable_post_types' filter, which we use to allow / acknowledge specific capabilities for the Advanced Gutenberg Profile post type.

Adding customize_changeset as an explicitly unfilterable post type ensure that no other PublishPress Capabilities or PublishPress Permissions code will acknowledge its selection under Capabilities 1.10. 