### PR TITLE
#16-Block access to frontend menu links

### DIFF
--- a/capsman-enhanced.php
+++ b/capsman-enhanced.php
@@ -20,28 +20,28 @@
  * Copyright (c) 2009, 2010 Jordi Canals
  * ------------------------------------------------------------------------------
  *
- * @package 	capability-manager-enhanced
- * @author		PublishPress
+ * @package    capability-manager-enhanced
+ * @author        PublishPress
  * @copyright   Copyright (C) 2009, 2010 Jordi Canals; modifications Copyright (C) 2020 PublishPress
- * @license		GNU General Public License version 3
- * @link		https://publishpress.com/
- * @version 	1.10.1
+ * @license        GNU General Public License version 3
+ * @link        https://publishpress.com/
+ * @version    1.10.1
  */
 
 if (!defined('CAPSMAN_VERSION')) {
-	define('CAPSMAN_VERSION', 			'1.10.1');
-	define('CAPSMAN_ENH_VERSION', 		'1.10.1');
-	define('PUBLISHPRESS_CAPS_VERSION', '1.10.1');
+    define('CAPSMAN_VERSION', '1.10.1');
+    define('CAPSMAN_ENH_VERSION', '1.10.1');
+    define('PUBLISHPRESS_CAPS_VERSION', '1.10.1');
 }
 
 foreach (get_option('active_plugins') as $plugin_file) {
-	if ( false !== strpos($plugin_file, 'capsman.php') ) {
-		add_action('admin_notices', function() {
-			$message = __( '<strong>Error:</strong> PublishPress Capabilities cannot function because another copy of Capability Manager is active.', 'capsman-enhanced' );
-			echo '<div id="message" class="error fade" style="color: black">' . $message . '</div>';
-		});
-		return;
-	}
+    if (false !== strpos($plugin_file, 'capsman.php')) {
+        add_action('admin_notices', function () {
+            $message = __('<strong>Error:</strong> PublishPress Capabilities cannot function because another copy of Capability Manager is active.', 'capsman-enhanced');
+            echo '<div id="message" class="error fade" style="color: black">' . $message . '</div>';
+        });
+        return;
+    }
 }
 
 $pro_active = false;
@@ -65,10 +65,9 @@ if (!$pro_active && is_multisite()) {
 if ($pro_active) {
     add_filter(
         'plugin_row_meta',
-        function($links, $file)
-        {
+        function ($links, $file) {
             if ($file == plugin_basename(__FILE__)) {
-                $links[]= __('<strong>This plugin can be deleted.</strong>', 'press-permit-core');
+                $links[] = __('<strong>This plugin can be deleted.</strong>', 'press-permit-core');
             }
 
             return $links;
@@ -78,67 +77,67 @@ if ($pro_active) {
 }
 
 if (defined('CME_FILE') || $pro_active) {
-	return;
+    return;
 }
 
-define ( 'CME_FILE', __FILE__ );
-define ('PUBLISHPRESS_CAPS_ABSPATH', __DIR__);
+define('CME_FILE', __FILE__);
+define('PUBLISHPRESS_CAPS_ABSPATH', __DIR__);
 
-require_once (dirname(__FILE__) . '/includes/functions.php');
+require_once(dirname(__FILE__) . '/includes/functions.php');
 
 if (is_admin()) {
-	require_once (dirname(__FILE__) . '/includes/functions-admin.php');
+    require_once(dirname(__FILE__) . '/includes/functions-admin.php');
 }
 
 // ============================================ START PROCEDURE ==========
 
 // Check required PHP version.
-if ( version_compare(PHP_VERSION, '5.4.0', '<') ) {
-	// Send an armin warning
-	add_action('admin_notices', function() {
-		$data = get_plugin_data(__FILE__);
-		load_plugin_textdomain('capsman-enhanced', false, basename(dirname(__FILE__)) .'/lang');
+if (version_compare(PHP_VERSION, '5.4.0', '<')) {
+    // Send an armin warning
+    add_action('admin_notices', function () {
+        $data = get_plugin_data(__FILE__);
+        load_plugin_textdomain('capsman-enhanced', false, basename(dirname(__FILE__)) . '/lang');
 
-		echo '<div class="error"><p><strong>' . __('Warning:', 'capsman-enhanced') . '</strong> '
-			. sprintf(__('The active plugin %s is not compatible with your PHP version.', 'capsman-enhanced') .'</p><p>',
-				'&laquo;' . $data['Name'] . ' ' . $data['Version'] . '&raquo;')
-			. sprintf(__('%s is required for this plugin.', 'capsman-enhanced'), 'PHP-5 ')
-			. '</p></div>';
-	});
+        echo '<div class="error"><p><strong>' . __('Warning:', 'capsman-enhanced') . '</strong> '
+            . sprintf(__('The active plugin %s is not compatible with your PHP version.', 'capsman-enhanced') . '</p><p>',
+                '&laquo;' . $data['Name'] . ' ' . $data['Version'] . '&raquo;')
+            . sprintf(__('%s is required for this plugin.', 'capsman-enhanced'), 'PHP-5 ')
+            . '</p></div>';
+    });
 } else {
-	global $pagenow;
+    global $pagenow;
 
-	if ( is_admin() &&
-	( isset($_REQUEST['page']) && in_array( $_REQUEST['page'], array( 'capsman', 'capsman-pp-admin-menus', 'capsman-tool' ) )
-	|| ( ! empty($_SERVER['SCRIPT_NAME']) && strpos( $_SERVER['SCRIPT_NAME'], 'p-admin/plugins.php' ) && ! empty($_REQUEST['action'] ) )
-	|| ( isset($_GET['action']) && 'reset-defaults' == $_GET['action'] )
-	|| in_array( $pagenow, array( 'users.php', 'user-edit.php', 'profile.php', 'user-new.php' ) )
-	) ) {
-		global $capsman;
+    if (is_admin() &&
+        (isset($_REQUEST['page']) && in_array($_REQUEST['page'], array('capsman', 'capsman-pp-admin-menus', 'capsman-pp-nav-menus', 'capsman-tool'))
+            || (!empty($_SERVER['SCRIPT_NAME']) && strpos($_SERVER['SCRIPT_NAME'], 'p-admin/plugins.php') && !empty($_REQUEST['action']))
+            || (isset($_GET['action']) && 'reset-defaults' == $_GET['action'])
+            || in_array($pagenow, array('users.php', 'user-edit.php', 'profile.php', 'user-new.php'))
+        )) {
+        global $capsman;
 
-		// Run the plugin
-		require_once ( dirname(__FILE__) . '/framework/lib/formating.php' );
-		require_once ( dirname(__FILE__) . '/framework/lib/users.php' );
+        // Run the plugin
+        require_once(dirname(__FILE__) . '/framework/lib/formating.php');
+        require_once(dirname(__FILE__) . '/framework/lib/users.php');
 
-		require_once ( dirname(__FILE__) . '/includes/manager.php' );
-		$capsman = new CapabilityManager();
-	} else {
-		load_plugin_textdomain('capsman-enhanced', false, basename(dirname(__FILE__)) .'/lang');
-		add_action( 'admin_menu', 'cme_submenus', 20 );
-	}
+        require_once(dirname(__FILE__) . '/includes/manager.php');
+        $capsman = new CapabilityManager();
+    } else {
+        load_plugin_textdomain('capsman-enhanced', false, basename(dirname(__FILE__)) . '/lang');
+        add_action('admin_menu', 'cme_submenus', 20);
+    }
 
-	if (is_admin() && !defined('PUBLISHPRESS_CAPS_PRO_VERSION')) {
-		require_once(__DIR__ . '/includes/CoreAdmin.php');
-		new \PublishPress\Capabilities\CoreAdmin();
-	}
+    if (is_admin() && !defined('PUBLISHPRESS_CAPS_PRO_VERSION')) {
+        require_once(__DIR__ . '/includes/CoreAdmin.php');
+        new \PublishPress\Capabilities\CoreAdmin();
+    }
 }
 
-add_action( 'init', '_cme_init' );
-add_action( 'plugins_loaded', '_cme_act_pp_active', 1 );
+add_action('init', '_cme_init');
+add_action('plugins_loaded', '_cme_act_pp_active', 1);
 
-add_action( 'init', '_cme_cap_helper', 49 );  // Press Permit Cap Helper, registered at 50, will leave caps which we've already defined
+add_action('init', '_cme_cap_helper', 49);  // Press Permit Cap Helper, registered at 50, will leave caps which we've already defined
 //add_action( 'wp_loaded', '_cme_cap_helper_late_init', 99 );	// now instead adding registered_post_type, registered_taxonomy action handlers for latecomers
-																// @todo: do this in PP Core also
+// @todo: do this in PP Core also
 
-if ( is_multisite() )
-	require_once ( dirname(__FILE__) . '/includes/network.php' );
+if (is_multisite())
+    require_once(dirname(__FILE__) . '/includes/network.php');

--- a/framework/styles/admin.css
+++ b/framework/styles/admin.css
@@ -262,6 +262,11 @@ table#akmin td.sidebar dd {
     visibility: visible;
 }
 
+.ppc-menu-item.parent .menu-item-link {
+    text-transform: uppercase;
+    color: darkgrey;
+}
+
 @media only screen and ( max-width: 782px ) {
 
     .pp-capability-menus {

--- a/includes/CoreAdmin.php
+++ b/includes/CoreAdmin.php
@@ -1,25 +1,29 @@
 <?php
+
 namespace PublishPress\Capabilities;
 
-class CoreAdmin {
-    function __construct() {
+class CoreAdmin
+{
+    function __construct()
+    {
         add_action('admin_print_scripts', [$this, 'setUpgradeMenuLink'], 50);
 
         if (is_admin()) {
             $autoloadPath = PUBLISHPRESS_CAPS_ABSPATH . '/vendor/autoload.php';
-			if (file_exists($autoloadPath)) {
-				require_once $autoloadPath;
-			}
+            if (file_exists($autoloadPath)) {
+                require_once $autoloadPath;
+            }
 
             require_once PUBLISHPRESS_CAPS_ABSPATH . '/vendor/publishpress/wordpress-version-notices/includes.php';
 
             add_filter(\PPVersionNotices\Module\TopNotice\Module::SETTINGS_FILTER, function ($settings) {
                 $settings['capabilities'] = [
                     'message' => 'You\'re using PublishPress Capabilities Free. The Pro version has more features and support. %sUpgrade to Pro%s',
-                    'link'    => 'https://publishpress.com/links/capabilities-banner',
+                    'link' => 'https://publishpress.com/links/capabilities-banner',
                     'screens' => [
                         ['base' => 'toplevel_page_capsman'],
                         ['base' => 'capabilities_page_capsman-pp-admin-menus'],
+                        ['base' => 'capabilities_page_capsman-pp-nav-menus'],
                         ['base' => 'capabilities_page_capsman-tool'],
                         ['base' => 'capabilities_page_capability-settings'],
                     ]
@@ -30,26 +34,26 @@ class CoreAdmin {
         }
     }
 
-    function setUpgradeMenuLink() {
+    function setUpgradeMenuLink()
+    {
         $url = 'https://publishpress.com/links/capabilities-menu';
         ?>
 
         <script type="text/javascript">
 
-            jQuery(document).ready(function($) {
+            jQuery(document).ready(function ($) {
 
                 var current_link, links = $('#toplevel_page_capsman ul li a');
 
                 $.each(links, function () {
                     current_link = $(this).attr('href');
                     current_link = current_link.split('=')[1];
-                    if(current_link === 'capabilities-pro')
-                    {
+                    if (current_link === 'capabilities-pro') {
                         $(this).attr('href', '<?php echo $url;?>').attr('target', '_blank').css('font-weight', 'bold').css('color', '#FEB123');
                     }
-                 });
+                });
             });
         </script>
-		<?php
+        <?php
     }
 }

--- a/includes/functions-admin.php
+++ b/includes/functions-admin.php
@@ -1,15 +1,16 @@
 <?php
 
 // perf enhancement: display submenu links without loading framework and plugin code
-function cme_submenus() {
+function cme_submenus()
+{
     // First we check if user is administrator and can 'manage_capabilities'.
-    if (current_user_can('administrator') && ! current_user_can('manage_capabilities')) {
+    if (current_user_can('administrator') && !current_user_can('manage_capabilities')) {
         if ($admin = get_role('administrator')) {
-        	$admin->add_cap('manage_capabilities');
+            $admin->add_cap('manage_capabilities');
         }
     }
 
-	$cap_name = (is_multisite() && is_super_admin()) ? 'read' : 'manage_capabilities';
+    $cap_name = (is_multisite() && is_super_admin()) ? 'read' : 'manage_capabilities';
 
     $permissions_title = __('Capabilities', 'capsman-enhanced');
 
@@ -17,7 +18,7 @@ function cme_submenus() {
 
     if (defined('PUBLISHPRESS_PERMISSIONS_MENU_GROUPING')) {
         foreach (get_option('active_plugins') as $plugin_file) {
-            if ( false !== strpos($plugin_file, 'publishpress.php') ) {
+            if (false !== strpos($plugin_file, 'publishpress.php')) {
                 $menu_order = 27;
             }
         }
@@ -30,24 +31,27 @@ function cme_submenus() {
         'capsman',
         'cme_fakefunc',
         'dashicons-admin-network',
-		$menu_order
+        $menu_order
     );
 
-    add_submenu_page('capsman',  __('Admin Menus', 'capsman-enhanced'), __('Admin Menus', 'capsman-enhanced'), $cap_name, 'capsman' . '-pp-admin-menus', 'cme_fakefunc');
+    add_submenu_page('capsman', __('Admin Menus', 'capsman-enhanced'), __('Admin Menus', 'capsman-enhanced'), $cap_name, 'capsman' . '-pp-admin-menus', 'cme_fakefunc');
 
-    add_submenu_page('capsman',  __('Backup', 'capsman-enhanced'), __('Backup', 'capsman-enhanced'), $cap_name, 'capsman' . '-tool', 'cme_fakefunc');
+    add_submenu_page('capsman', __('Nav Menus', 'capsman-enhanced'), __('Nav Menus', 'capsman-enhanced'), $cap_name, 'capsman' . '-pp-nav-menus', 'cme_fakefunc');
 
-	if (!defined('PUBLISHPRESS_CAPS_PRO_VERSION')) {
-	    add_submenu_page(
-	        'capsman',
-	        __('Upgrade to Pro', 'capsman-enhanced'),
-	        __('Upgrade to Pro', 'capsman-enhanced'),
-	        'manage_capabilities',
-	        'capabilities-pro',
-	        'cme_fakefunc'
-	    );
-	}
+    add_submenu_page('capsman', __('Backup', 'capsman-enhanced'), __('Backup', 'capsman-enhanced'), $cap_name, 'capsman' . '-tool', 'cme_fakefunc');
+
+    if (!defined('PUBLISHPRESS_CAPS_PRO_VERSION')) {
+        add_submenu_page(
+            'capsman',
+            __('Upgrade to Pro', 'capsman-enhanced'),
+            __('Upgrade to Pro', 'capsman-enhanced'),
+            'manage_capabilities',
+            'capabilities-pro',
+            'cme_fakefunc'
+        );
+    }
 }
 
-function cme_fakefunc() {
+function cme_fakefunc()
+{
 }

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -332,11 +332,11 @@ function pp_capabilities_nav_menu_access($query)
 
     if ($disabled_nav_menu) {
 
-//we only need object id and object name e.g, 1_category
+        //we only need object id and object name e.g, 1_category
         $disabled_object = preg_replace('!(0|[1-9][0-9]*)_([a-zA-Z0-9_.-]*),!s', '$2,', $disabled_nav_menu);
         $disabled_nav_menu_array = array_filter(explode(", ", $disabled_object));
 
-//category tags and taxonomy page check
+        //category tags and taxonomy page check
         if (is_category() || is_tag() || is_tax()) {
             $taxonomy_id = get_queried_object()->term_id;
             $taxonnomy_type = get_queried_object()->taxonomy;
@@ -348,7 +348,7 @@ function pp_capabilities_nav_menu_access($query)
             }
         }
 
-//post, page, cpt check
+        //post, page, cpt check
         if (is_singular()) {
             $post_type = get_post_type();
             $post_id = get_the_ID();

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -234,7 +234,7 @@ function pp_cabapbility_admin_menu_access_denied()
     wp_die(esc_html($forbidden));
 }
 
-function pp_cabapbility_nav_menu_access_denied()
+function pp_capability_nav_menu_access_denied()
 {
     $forbidden = esc_attr__('You did not have permission to access this page.', 'capsman-enhanced');
     wp_die(esc_html($forbidden));
@@ -343,7 +343,7 @@ function pp_capabilities_nav_menu_access($query)
             foreach ($disabled_nav_menu_array as $item_option) {
                 $option_object = $taxonomy_id . '_' . $taxonnomy_type;
                 if (in_array($option_object, $disabled_nav_menu_array)) {
-                    pp_cabapbility_nav_menu_access_denied();
+                    pp_capability_nav_menu_access_denied();
                 }
             }
         }
@@ -355,7 +355,7 @@ function pp_capabilities_nav_menu_access($query)
             foreach ($disabled_nav_menu_array as $item_option) {
                 $option_object = $post_id . '_' . $post_type;
                 if (in_array($option_object, $disabled_nav_menu_array)) {
-                    pp_cabapbility_nav_menu_access_denied();
+                    pp_capability_nav_menu_access_denied();
                 }
             }
         }

--- a/includes/manager.php
+++ b/includes/manager.php
@@ -3,192 +3,197 @@
  * Capability Manager.
  * Plugin to create and manage roles and capabilities.
  *
- * @author		Jordi Canals, Kevin Behrens
+ * @author        Jordi Canals, Kevin Behrens
  * @copyright   Copyright (C) 2009, 2010 Jordi Canals, (C) 2020 PublishPress
- * @license		GNU General Public License version 2
- * @link		https://publishpress.com/
+ * @license        GNU General Public License version 2
+ * @link        https://publishpress.com/
  *
  *
- *	Copyright 2009, 2010 Jordi Canals <devel@jcanals.cat>
+ *    Copyright 2009, 2010 Jordi Canals <devel@jcanals.cat>
  *
- *	Modifications Copyright 2020, PublishPress <help@publishpress.com>
+ *    Modifications Copyright 2020, PublishPress <help@publishpress.com>
  *
- *	This program is free software; you can redistribute it and/or
- *	modify it under the terms of the GNU General Public License
- *	version 2 as published by the Free Software Foundation.
+ *    This program is free software; you can redistribute it and/or
+ *    modify it under the terms of the GNU General Public License
+ *    version 2 as published by the Free Software Foundation.
  *
- *	This program is distributed in the hope that it will be useful,
- *	but WITHOUT ANY WARRANTY; without even the implied warranty of
- *	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *	GNU General Public License for more details.
+ *    This program is distributed in the hope that it will be useful,
+ *    but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *    GNU General Public License for more details.
  *
  *  You should have received a copy of the GNU General Public License
  *  along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
-add_action( 'init', 'cme_update_pp_usage' );  // update early so resulting post type cap changes are applied for this request's UI construction
+add_action('init', 'cme_update_pp_usage');  // update early so resulting post type cap changes are applied for this request's UI construction
 
-function cme_update_pp_usage() {
-	if ( ! empty($_REQUEST['update_filtered_types']) || ! empty($_REQUEST['update_filtered_taxonomies']) || ! empty($_REQUEST['update_detailed_taxonomies']) || ! empty($_REQUEST['SaveRole']) ) {
-		require_once( dirname(__FILE__).'/pp-handler.php' );
-		return _cme_update_pp_usage();
-	}
+function cme_update_pp_usage()
+{
+    if (!empty($_REQUEST['update_filtered_types']) || !empty($_REQUEST['update_filtered_taxonomies']) || !empty($_REQUEST['update_detailed_taxonomies']) || !empty($_REQUEST['SaveRole'])) {
+        require_once(dirname(__FILE__) . '/pp-handler.php');
+        return _cme_update_pp_usage();
+    }
 }
 
 // Core WP roles to apply safeguard preventing accidental lockout from dashboard
-function _cme_core_roles() {
-	return apply_filters( 'pp_caps_core_roles', array( 'administrator', 'editor', 'revisor', 'author', 'contributor', 'subscriber' ) );
+function _cme_core_roles()
+{
+    return apply_filters('pp_caps_core_roles', array('administrator', 'editor', 'revisor', 'author', 'contributor', 'subscriber'));
 }
 
-function _cme_core_caps() {
-	$core_caps = array_fill_keys( array( 'switch_themes', 'edit_themes', 'activate_plugins', 'edit_plugins', 'edit_users', 'edit_files', 'manage_options', 'moderate_comments',
-	'manage_links', 'upload_files', 'import', 'unfiltered_html', 'read', 'delete_users', 'create_users', 'unfiltered_upload', 'edit_dashboard',
-	'update_plugins', 'delete_plugins', 'install_plugins', 'update_themes', 'install_themes',
-	'update_core', 'list_users', 'remove_users', 'promote_users', 'edit_theme_options', 'delete_themes', 'export' ), true );
+function _cme_core_caps()
+{
+    $core_caps = array_fill_keys(array('switch_themes', 'edit_themes', 'activate_plugins', 'edit_plugins', 'edit_users', 'edit_files', 'manage_options', 'moderate_comments',
+        'manage_links', 'upload_files', 'import', 'unfiltered_html', 'read', 'delete_users', 'create_users', 'unfiltered_upload', 'edit_dashboard',
+        'update_plugins', 'delete_plugins', 'install_plugins', 'update_themes', 'install_themes',
+        'update_core', 'list_users', 'remove_users', 'promote_users', 'edit_theme_options', 'delete_themes', 'export'), true);
 
-	ksort( $core_caps );
-	return $core_caps;
+    ksort($core_caps);
+    return $core_caps;
 }
 
-function _cme_is_read_removal_blocked( $role_name ) {
-	$role = get_role($role_name);
-	$rcaps = $role->capabilities;
+function _cme_is_read_removal_blocked($role_name)
+{
+    $role = get_role($role_name);
+    $rcaps = $role->capabilities;
 
-	$core_caps = array_diff_key( _cme_core_caps(), array_fill_keys( array( 'unfiltered_html', 'unfiltered_upload', 'upload_files', 'edit_files', 'read' ), true ) );
+    $core_caps = array_diff_key(_cme_core_caps(), array_fill_keys(array('unfiltered_html', 'unfiltered_upload', 'upload_files', 'edit_files', 'read'), true));
 
-	if ( empty( $rcaps['dashboard_lockout_ok'] ) ) {
-		$edit_caps = array();
-		foreach ( get_post_types( array( 'public' => true ), 'object' ) as $type_obj ) {
-			$edit_caps = array_merge( $edit_caps, array_values( array_diff_key( (array) $type_obj->cap, array( 'read_private_posts' => true ) ) ) );
-		}
+    if (empty($rcaps['dashboard_lockout_ok'])) {
+        $edit_caps = array();
+        foreach (get_post_types(array('public' => true), 'object') as $type_obj) {
+            $edit_caps = array_merge($edit_caps, array_values(array_diff_key((array)$type_obj->cap, array('read_private_posts' => true))));
+        }
 
-		$edit_caps = array_fill_keys( $edit_caps, true );
-		unset( $edit_caps['read'] );
-		unset( $edit_caps['upload_files'] );
-		unset( $edit_caps['edit_files'] );
+        $edit_caps = array_fill_keys($edit_caps, true);
+        unset($edit_caps['read']);
+        unset($edit_caps['upload_files']);
+        unset($edit_caps['edit_files']);
 
-		if ( $role_has_admin_caps = in_array( $role_name, _cme_core_roles() ) && ( array_intersect_key( $rcaps, array_diff_key( $core_caps, array( 'read' => true ) ) ) || array_intersect_key( $rcaps, $edit_caps ) ) ) {
-			return true;
-		}
-	}
+        if ($role_has_admin_caps = in_array($role_name, _cme_core_roles()) && (array_intersect_key($rcaps, array_diff_key($core_caps, array('read' => true))) || array_intersect_key($rcaps, $edit_caps))) {
+            return true;
+        }
+    }
 
-	return false;
+    return false;
 }
 
 /**
  * Class CapabilityManager.
  * Sets the main environment for all Capability Manager components.
  *
- * @author		Jordi Canals, Kevin Behrens
- * @link		https://publishpress.com/
+ * @author        Jordi Canals, Kevin Behrens
+ * @link        https://publishpress.com/
  */
 class CapabilityManager
 {
-	/**
-	 * Array with all capabilities to be managed. (Depends on user caps).
-	 * The array keys are the capability, the value is its screen name.
-	 * @var array
-	 */
-	var $capabilities = array();
+    /**
+     * Array with all capabilities to be managed. (Depends on user caps).
+     * The array keys are the capability, the value is its screen name.
+     * @var array
+     */
+    var $capabilities = array();
 
-	/**
-	 * Array with roles that can be managed. (Depends on user roles).
-	 * The array keys are the role name, the value is its translated name.
-	 * @var array
-	 */
-	var $roles = array();
+    /**
+     * Array with roles that can be managed. (Depends on user roles).
+     * The array keys are the role name, the value is its translated name.
+     * @var array
+     */
+    var $roles = array();
 
-	/**
-	 * Current role we are managing
-	 * @var string
-	 */
-	var $current;
+    /**
+     * Current role we are managing
+     * @var string
+     */
+    var $current;
 
-	/**
-	 * Maximum level current manager can assign to a user.
-	 * @var int
-	 */
-	private $max_level;
+    /**
+     * Maximum level current manager can assign to a user.
+     * @var int
+     */
+    private $max_level;
 
-	private $log_db_role_objects = array();
+    private $log_db_role_objects = array();
 
-	var $message;
+    var $message;
 
-	/**
-	 * Module ID. Is the module internal short name.
-	 *
-	 * @var string
-	 */
-	public $ID;
+    /**
+     * Module ID. Is the module internal short name.
+     *
+     * @var string
+     */
+    public $ID;
 
-	public function __construct()
-	{
-		$this->ID = 'capsman';
-		$this->mod_url = plugins_url( '', CME_FILE );
+    public function __construct()
+    {
+        $this->ID = 'capsman';
+        $this->mod_url = plugins_url('', CME_FILE);
 
-		$this->moduleLoad();
+        $this->moduleLoad();
 
-		add_action('admin_menu', array($this, 'adminMenus'), 5);  // execute prior to PP, to use menu hook
+        add_action('admin_menu', array($this, 'adminMenus'), 5);  // execute prior to PP, to use menu hook
 
-		// Load styles
-		add_action('admin_print_styles', array($this, 'adminStyles'));
+        // Load styles
+        add_action('admin_print_styles', array($this, 'adminStyles'));
 
-		if ( isset($_REQUEST['page']) && ( 'capsman' == $_REQUEST['page'] ) ) {
-			add_action('admin_enqueue_scripts', array($this, 'adminScriptsPP'));
-		}
-	}
+        if (isset($_REQUEST['page']) && ('capsman' == $_REQUEST['page'])) {
+            add_action('admin_enqueue_scripts', array($this, 'adminScriptsPP'));
+        }
+    }
 
     /**
      * Enqueues administration styles.
      *
      * @hook action 'admin_print_styles'
-	 *
+     *
      * @return void
      */
     function adminStyles()
     {
-		if ( empty( $_REQUEST['page'] ) || ! in_array( $_REQUEST['page'], array( 'capsman', 'capsman-pp-admin-menus', 'capsman-tool' ) ) )
-			return;
+        if (empty($_REQUEST['page']) || !in_array($_REQUEST['page'], array('capsman', 'capsman-pp-admin-menus', 'capsman-pp-nav-menus', 'capsman-tool')))
+            return;
 
-		wp_enqueue_style('cme-admin-common', $this->mod_url . '/common/css/pressshack-admin.css', [], PUBLISHPRESS_CAPS_VERSION);
+        wp_enqueue_style('cme-admin-common', $this->mod_url . '/common/css/pressshack-admin.css', [], PUBLISHPRESS_CAPS_VERSION);
 
-		wp_register_style( $this->ID . 'framework_admin', $this->mod_url . '/framework/styles/admin.css', false, PUBLISHPRESS_CAPS_VERSION);
-   		wp_enqueue_style( $this->ID . 'framework_admin');
+        wp_register_style($this->ID . 'framework_admin', $this->mod_url . '/framework/styles/admin.css', false, PUBLISHPRESS_CAPS_VERSION);
+        wp_enqueue_style($this->ID . 'framework_admin');
 
-   		wp_register_style( $this->ID . '_admin', $this->mod_url . '/admin.css', false, PUBLISHPRESS_CAPS_VERSION);
-   		wp_enqueue_style( $this->ID . '_admin');
+        wp_register_style($this->ID . '_admin', $this->mod_url . '/admin.css', false, PUBLISHPRESS_CAPS_VERSION);
+        wp_enqueue_style($this->ID . '_admin');
 
-		$suffix = defined('SCRIPT_DEBUG') && SCRIPT_DEBUG ? '.dev' : '';
-		$url = $this->mod_url . "/admin{$suffix}.js";
-		wp_enqueue_script( 'cme_admin', $url, array('jquery'), PUBLISHPRESS_CAPS_VERSION, true );
-		wp_localize_script( 'cme_admin', 'cmeAdmin', array(
-			'negationCaption' => __( 'Explicity negate this capability by storing as disabled', 'capsman-enhanced' ),
-			'typeCapsNegationCaption' => __( 'Explicitly negate these capabilities by storing as disabled', 'capsman-enhanced' ),
-			'typeCapUnregistered' => __( 'Post type registration does not define this capability distinctly', 'capsman-enhanced' ),
-			'capNegated' => __( 'This capability is explicitly negated. Click to add/remove normally.', 'capsman-enhanced' ),
-			'chkCaption' => __( 'Add or remove this capability from the WordPress role', 'capsman-enhanced' ),
-			'switchableCaption' => __( 'Add or remove capability from the role normally', 'capsman-enhanced' ) )
-		);
+        $suffix = defined('SCRIPT_DEBUG') && SCRIPT_DEBUG ? '.dev' : '';
+        $url = $this->mod_url . "/admin{$suffix}.js";
+        wp_enqueue_script('cme_admin', $url, array('jquery'), PUBLISHPRESS_CAPS_VERSION, true);
+        wp_localize_script('cme_admin', 'cmeAdmin', array(
+                'negationCaption' => __('Explicity negate this capability by storing as disabled', 'capsman-enhanced'),
+                'typeCapsNegationCaption' => __('Explicitly negate these capabilities by storing as disabled', 'capsman-enhanced'),
+                'typeCapUnregistered' => __('Post type registration does not define this capability distinctly', 'capsman-enhanced'),
+                'capNegated' => __('This capability is explicitly negated. Click to add/remove normally.', 'capsman-enhanced'),
+                'chkCaption' => __('Add or remove this capability from the WordPress role', 'capsman-enhanced'),
+                'switchableCaption' => __('Add or remove capability from the role normally', 'capsman-enhanced'))
+        );
     }
 
-	function adminScriptsPP() {
-		wp_enqueue_style( 'plugin-install' );
-		wp_enqueue_script( 'plugin-install' );
-		add_thickbox();
-	}
-
-	/**
-	 * Creates some filters at module load time.
-	 *
-	 * @return void
-	 */
-    protected function moduleLoad ()
+    function adminScriptsPP()
     {
-		$old_version = get_option($this->ID . '_version');
-		if ( version_compare( $old_version, PUBLISHPRESS_CAPS_VERSION, 'ne') ) {
-			update_option($this->ID . '_version', PUBLISHPRESS_CAPS_VERSION);
-			$this->pluginUpdate();
-		}
+        wp_enqueue_style('plugin-install');
+        wp_enqueue_script('plugin-install');
+        add_thickbox();
+    }
+
+    /**
+     * Creates some filters at module load time.
+     *
+     * @return void
+     */
+    protected function moduleLoad()
+    {
+        $old_version = get_option($this->ID . '_version');
+        if (version_compare($old_version, PUBLISHPRESS_CAPS_VERSION, 'ne')) {
+            update_option($this->ID . '_version', PUBLISHPRESS_CAPS_VERSION);
+            $this->pluginUpdate();
+        }
 
         // Only roles that a user can administer can be assigned to others.
         add_filter('editable_roles', array($this, 'filterEditRoles'));
@@ -196,548 +201,615 @@ class CapabilityManager
         // Users with roles that cannot be managed, are not allowed to be edited.
         add_filter('map_meta_cap', array(&$this, 'filterUserEdit'), 10, 4);
 
-		// ensure storage, retrieval of db-stored customizations to dynamic roles
-		if ( isset($_REQUEST['page']) && in_array( $_REQUEST['page'], array( 'capsman', 'capsman-tool' ) ) ) {
-			global $wpdb;
-			$role_key = $wpdb->prefix . 'user_roles';
-			$this->log_db_roles();
-			add_filter( 'option_' . $role_key, array( &$this, 'reinstate_db_roles' ), PHP_INT_MAX );
-		}
+        // ensure storage, retrieval of db-stored customizations to dynamic roles
+        if (isset($_REQUEST['page']) && in_array($_REQUEST['page'], array('capsman', 'capsman-tool'))) {
+            global $wpdb;
+            $role_key = $wpdb->prefix . 'user_roles';
+            $this->log_db_roles();
+            add_filter('option_' . $role_key, array(&$this, 'reinstate_db_roles'), PHP_INT_MAX);
+        }
 
-		add_filter( 'plugins_loaded', array( &$this, 'processRoleUpdate' ) );
+        add_filter('plugins_loaded', array(&$this, 'processRoleUpdate'));
     }
 
-	// Direct query of stored role definitions
-	function log_db_roles( $legacy_arg = '' ) {
-		global $wpdb;
+    // Direct query of stored role definitions
+    function log_db_roles($legacy_arg = '')
+    {
+        global $wpdb;
 
-		$results = (array) maybe_unserialize( $wpdb->get_var("SELECT option_value FROM $wpdb->options WHERE option_name = '{$wpdb->prefix}user_roles' LIMIT 1") );
-		foreach( $results as $_role_name => $_role ) {
-			$this->log_db_role_objects[$_role_name] = (object) $_role;
-		}
+        $results = (array)maybe_unserialize($wpdb->get_var("SELECT option_value FROM $wpdb->options WHERE option_name = '{$wpdb->prefix}user_roles' LIMIT 1"));
+        foreach ($results as $_role_name => $_role) {
+            $this->log_db_role_objects[$_role_name] = (object)$_role;
+        }
 
-		return $legacy_arg;
-	}
+        return $legacy_arg;
+    }
 
-	// note: this is only applied when accessing the cme role edit form
-	function reinstate_db_roles( $passthru_roles = array() ) {
-		global $wp_roles;
+    // note: this is only applied when accessing the cme role edit form
+    function reinstate_db_roles($passthru_roles = array())
+    {
+        global $wp_roles;
 
-		if ( isset($wp_roles) && $this->log_db_role_objects ) {
-			$intersect = array_intersect_key( $wp_roles->role_objects, $this->log_db_role_objects );
-			foreach( array_keys( $intersect ) as $key ) {
-				if ( ! empty( $this->log_db_role_objects[$key]->capabilities ) )
-					$wp_roles->role_objects[$key]->capabilities = $this->log_db_role_objects[$key]->capabilities;
-			}
-		}
+        if (isset($wp_roles) && $this->log_db_role_objects) {
+            $intersect = array_intersect_key($wp_roles->role_objects, $this->log_db_role_objects);
+            foreach (array_keys($intersect) as $key) {
+                if (!empty($this->log_db_role_objects[$key]->capabilities))
+                    $wp_roles->role_objects[$key]->capabilities = $this->log_db_role_objects[$key]->capabilities;
+            }
+        }
 
-		return $passthru_roles;
-	}
+        return $passthru_roles;
+    }
 
-	/**
-	 * Updates Capability Manager to a new version
-	 *
-	 * @return void
-	 */
-	protected function pluginUpdate ()
-	{
-		global $wpdb;
+    /**
+     * Updates Capability Manager to a new version
+     *
+     * @return void
+     */
+    protected function pluginUpdate()
+    {
+        global $wpdb;
 
-		$backup = get_option($this->ID . '_backup');
-		if ( false === $backup ) {		// No previous backup found. Save it!
-			global $wpdb;
-			$roles = get_option($wpdb->prefix . 'user_roles');
-			update_option( $this->ID . '_backup', $roles, false );
-			update_option( $this->ID . '_backup_datestamp', current_time( 'timestamp' ), false );
-		}
+        $backup = get_option($this->ID . '_backup');
+        if (false === $backup) {        // No previous backup found. Save it!
+            global $wpdb;
+            $roles = get_option($wpdb->prefix . 'user_roles');
+            update_option($this->ID . '_backup', $roles, false);
+            update_option($this->ID . '_backup_datestamp', current_time('timestamp'), false);
+        }
 
-		if (!$wpdb->get_var("SELECT COUNT(option_id) FROM $wpdb->options WHERE option_name LIKE 'cme_backup_auto_%'")) {
-			pp_capabilities_autobackup();
-		}
-	}
+        if (!$wpdb->get_var("SELECT COUNT(option_id) FROM $wpdb->options WHERE option_name LIKE 'cme_backup_auto_%'")) {
+            pp_capabilities_autobackup();
+        }
+    }
 
-	/**
-	 * Adds admin panel menus. (At plugins loading time. This is before plugins_loaded).
-	 * User needs to have 'manage_capabilities' to access this menus.
-	 * This is set as an action in the parent class constructor.
-	 *
-	 * @hook action admin_menu
-	 * @return void
-	 */
-	public function adminMenus ()
-	{
-		// First we check if user is administrator and can 'manage_capabilities'.
-		if ( current_user_can('administrator') && ! current_user_can('manage_capabilities') ) {
-			$this->setAdminCapability();
-		}
+    /**
+     * Adds admin panel menus. (At plugins loading time. This is before plugins_loaded).
+     * User needs to have 'manage_capabilities' to access this menus.
+     * This is set as an action in the parent class constructor.
+     *
+     * @hook action admin_menu
+     * @return void
+     */
+    public function adminMenus()
+    {
+        // First we check if user is administrator and can 'manage_capabilities'.
+        if (current_user_can('administrator') && !current_user_can('manage_capabilities')) {
+            $this->setAdminCapability();
+        }
 
-		add_action( 'admin_menu', array( &$this, 'cme_menu' ), 18 );
-	}
+        add_action('admin_menu', array(&$this, 'cme_menu'), 18);
+    }
 
-	public function cme_menu() {
-		$cap_name = (is_multisite() && is_super_admin()) ? 'read' : 'manage_capabilities';
+    public function cme_menu()
+    {
+        $cap_name = (is_multisite() && is_super_admin()) ? 'read' : 'manage_capabilities';
 
-		$permissions_title = __('Capabilities', 'capsman-enhanced');
+        $permissions_title = __('Capabilities', 'capsman-enhanced');
 
-		$menu_order = 72;
+        $menu_order = 72;
 
-		if (defined('PUBLISHPRESS_PERMISSIONS_MENU_GROUPING')) {
-			foreach (get_option('active_plugins') as $plugin_file) {
-				if ( false !== strpos($plugin_file, 'publishpress.php') ) {
-					$menu_order = 27;
-				}
-			}
-		}
+        if (defined('PUBLISHPRESS_PERMISSIONS_MENU_GROUPING')) {
+            foreach (get_option('active_plugins') as $plugin_file) {
+                if (false !== strpos($plugin_file, 'publishpress.php')) {
+                    $menu_order = 27;
+                }
+            }
+        }
 
-		add_menu_page(
-			$permissions_title,
-			$permissions_title,
-			$cap_name,
-			'capsman',
-			array($this, 'generalManager'),
-			'dashicons-admin-network',
-			$menu_order
-		);
+        add_menu_page(
+            $permissions_title,
+            $permissions_title,
+            $cap_name,
+            'capsman',
+            array($this, 'generalManager'),
+            'dashicons-admin-network',
+            $menu_order
+        );
 
-		add_submenu_page('capsman',  __('Admin Menus', 'capsman-enhanced'), __('Admin Menus', 'capsman-enhanced'), $cap_name, $this->ID . '-pp-admin-menus', array($this, 'pp_admin_menus'));
+        add_submenu_page('capsman', __('Admin Menus', 'capsman-enhanced'), __('Admin Menus', 'capsman-enhanced'), $cap_name, $this->ID . '-pp-admin-menus', array($this, 'pp_admin_menus'));
 
-		add_submenu_page('capsman',  __('Backup', 'capsman-enhanced'), __('Backup', 'capsman-enhanced'), $cap_name, $this->ID . '-tool', array($this, 'backupTool'));
+        add_submenu_page('capsman', __('Nav Menus', 'capsman-enhanced'), __('Nav Menus', 'capsman-enhanced'), $cap_name, $this->ID . '-pp-nav-menus', array($this, 'pp_nav_menus'));
 
-		if (!defined('PUBLISHPRESS_CAPS_PRO_VERSION')) {
-			add_submenu_page(
-	            'capsman',
-	            __('Upgrade to Pro', 'capsman-enhanced'),
-	            __('Upgrade to Pro', 'capsman-enhanced'),
-	            'manage_capabilities',
-	            'capabilities-pro',
-	            array($this, 'generalManager')
-	        );
-		}
-	}
+        add_submenu_page('capsman', __('Backup', 'capsman-enhanced'), __('Backup', 'capsman-enhanced'), $cap_name, $this->ID . '-tool', array($this, 'backupTool'));
 
-	/**
-	 * Sets the 'manage_capabilities' cap to the administrator role.
-	 *
-	 * @return void
-	 */
-	public function setAdminCapability ()
-	{
-		if ($admin = get_role('administrator')) {
-			$admin->add_cap('manage_capabilities');
-		}
-	}
+        if (!defined('PUBLISHPRESS_CAPS_PRO_VERSION')) {
+            add_submenu_page(
+                'capsman',
+                __('Upgrade to Pro', 'capsman-enhanced'),
+                __('Upgrade to Pro', 'capsman-enhanced'),
+                'manage_capabilities',
+                'capabilities-pro',
+                array($this, 'generalManager')
+            );
+        }
+    }
 
-	/**
-	 * Filters roles that can be shown in roles list.
-	 * This is mainly used to prevent an user admin to create other users with
-	 * higher capabilities.
-	 *
-	 * @hook 'editable_roles' filter.
-	 *
-	 * @param $roles List of roles to check.
-	 * @return array Restircted roles list
-	 */
-	function filterEditRoles ( $roles )
-	{
-	    $this->generateNames();
+    /**
+     * Sets the 'manage_capabilities' cap to the administrator role.
+     *
+     * @return void
+     */
+    public function setAdminCapability()
+    {
+        if ($admin = get_role('administrator')) {
+            $admin->add_cap('manage_capabilities');
+        }
+    }
+
+    /**
+     * Filters roles that can be shown in roles list.
+     * This is mainly used to prevent an user admin to create other users with
+     * higher capabilities.
+     *
+     * @hook 'editable_roles' filter.
+     *
+     * @param $roles List of roles to check.
+     * @return array Restircted roles list
+     */
+    function filterEditRoles($roles)
+    {
+        $this->generateNames();
         $valid = array_keys($this->roles);
 
-        foreach ( $roles as $role => $caps ) {
-            if ( ! in_array($role, $valid) ) {
+        foreach ($roles as $role => $caps) {
+            if (!in_array($role, $valid)) {
                 unset($roles[$role]);
             }
         }
 
         return $roles;
-	}
+    }
 
-	/**
-	 * Checks if a user can be edited or not by current administrator.
-	 * Returns array('do_not_allow') if user cannot be edited.
-	 *
-	 * @hook 'map_meta_cap' filter
-	 *
-	 * @param array $caps Current user capabilities
-	 * @param string $cap Capability to check
-	 * @param int $user_id Current user ID
-	 * @param array $args For our purpose, we receive edited user id at $args[0]
-	 * @return array Allowed capabilities.
-	 */
-	function filterUserEdit ( $caps, $cap, $user_id, $args )
-	{
-	    if ( ! in_array( $cap, array( 'edit_user', 'delete_user', 'promote_user', 'remove_user' ) ) || ( ! isset($args[0]) ) || $user_id == (int) $args[0] ) {
-	        return $caps;
-	    }
+    /**
+     * Checks if a user can be edited or not by current administrator.
+     * Returns array('do_not_allow') if user cannot be edited.
+     *
+     * @hook 'map_meta_cap' filter
+     *
+     * @param array $caps Current user capabilities
+     * @param string $cap Capability to check
+     * @param int $user_id Current user ID
+     * @param array $args For our purpose, we receive edited user id at $args[0]
+     * @return array Allowed capabilities.
+     */
+    function filterUserEdit($caps, $cap, $user_id, $args)
+    {
+        if (!in_array($cap, array('edit_user', 'delete_user', 'promote_user', 'remove_user')) || (!isset($args[0])) || $user_id == (int)$args[0]) {
+            return $caps;
+        }
 
-		$user = new WP_User( (int) $args[0] );
+        $user = new WP_User((int)$args[0]);
 
-		$this->generateNames();
+        $this->generateNames();
 
-		if ( defined( 'CME_LEGACY_USER_EDIT_FILTER' ) && CME_LEGACY_USER_EDIT_FILTER ) {
-			$valid = array_keys($this->roles);
+        if (defined('CME_LEGACY_USER_EDIT_FILTER') && CME_LEGACY_USER_EDIT_FILTER) {
+            $valid = array_keys($this->roles);
 
-			foreach ( $user->roles as $role ) {
-				if ( ! in_array($role, $valid) ) {
-					$caps = array('do_not_allow');
-					break;
-				}
-			}
-		} else {
-			global $wp_roles;
+            foreach ($user->roles as $role) {
+                if (!in_array($role, $valid)) {
+                    $caps = array('do_not_allow');
+                    break;
+                }
+            }
+        } else {
+            global $wp_roles;
 
-			foreach ( $user->roles as $role ) {
-				$r = get_role( $role );
-    			$level = ak_caps2level($r->capabilities);
+            foreach ($user->roles as $role) {
+                $r = get_role($role);
+                $level = ak_caps2level($r->capabilities);
 
-				if ( ( ! $level ) && ( 'administrator' == $role ) )
-					$level = 10;
+                if ((!$level) && ('administrator' == $role))
+                    $level = 10;
 
-	    		if ( $level > $this->max_level ) {
-		    		$caps = array('do_not_allow');
-					break;
-			    }
-    		}
+                if ($level > $this->max_level) {
+                    $caps = array('do_not_allow');
+                    break;
+                }
+            }
 
-		}
+        }
 
-		return $caps;
-	}
+        return $caps;
+    }
 
-	function processRoleUpdate() {
-		if ( 'POST' == $_SERVER['REQUEST_METHOD'] && ( ! empty($_REQUEST['SaveRole']) || ! empty($_REQUEST['AddCap']) ) ) {
-			if ((!is_multisite() || !is_super_admin()) && !current_user_can('administrator') && !current_user_can('manage_capabilities')) {
-				// TODO: Implement exceptions.
-				wp_die('<strong>' .__('You do not have permission to manage capabilities.', 'capsman-enhanced') . '</strong>');
-			}
+    function processRoleUpdate()
+    {
+        if ('POST' == $_SERVER['REQUEST_METHOD'] && (!empty($_REQUEST['SaveRole']) || !empty($_REQUEST['AddCap']))) {
+            if ((!is_multisite() || !is_super_admin()) && !current_user_can('administrator') && !current_user_can('manage_capabilities')) {
+                // TODO: Implement exceptions.
+                wp_die('<strong>' . __('You do not have permission to manage capabilities.', 'capsman-enhanced') . '</strong>');
+            }
 
-			if ( ! empty($_REQUEST['current']) ) { // don't process role update unless form variable is received
-				check_admin_referer('capsman-general-manager');
+            if (!empty($_REQUEST['current'])) { // don't process role update unless form variable is received
+                check_admin_referer('capsman-general-manager');
 
-				$role = get_role($_REQUEST['current']);
-				$current_level = ($role) ? ak_caps2level($role->capabilities) : 0;
+                $role = get_role($_REQUEST['current']);
+                $current_level = ($role) ? ak_caps2level($role->capabilities) : 0;
 
-				$this->processAdminGeneral();
+                $this->processAdminGeneral();
 
-				$set_level = (isset($_POST['level'])) ? $_POST['level'] : 0;
+                $set_level = (isset($_POST['level'])) ? $_POST['level'] : 0;
 
-				if ($set_level != $current_level) {
-					global $wp_roles, $wp_version;
+                if ($set_level != $current_level) {
+                    global $wp_roles, $wp_version;
 
-					if ( version_compare($wp_version, '4.9', '>=') ) {
-						$wp_roles->for_site();
-					} else {
-						$wp_roles->reinit();
-					}
+                    if (version_compare($wp_version, '4.9', '>=')) {
+                        $wp_roles->for_site();
+                    } else {
+                        $wp_roles->reinit();
+                    }
 
-					foreach( get_users(array('role' => $_REQUEST['current'], 'fields' => 'ID')) as $ID ) {
-						$user = new WP_User($ID);
-						$user->get_role_caps();
-						$user->update_user_level_from_caps();
-					}
-				}
-			}
-		}
-	}
+                    foreach (get_users(array('role' => $_REQUEST['current'], 'fields' => 'ID')) as $ID) {
+                        $user = new WP_User($ID);
+                        $user->get_role_caps();
+                        $user->update_user_level_from_caps();
+                    }
+                }
+            }
+        }
+    }
 
-	/**
-	 * Manages global settings admin.
-	 *
-	 * @hook add_submenu_page
-	 * @return void
-	 */
-	function generalManager () {
-		if ((!is_multisite() || !is_super_admin()) && !current_user_can('administrator') && !current_user_can('manage_capabilities')) {
+    /**
+     * Manages global settings admin.
+     *
+     * @hook add_submenu_page
+     * @return void
+     */
+    function generalManager()
+    {
+        if ((!is_multisite() || !is_super_admin()) && !current_user_can('administrator') && !current_user_can('manage_capabilities')) {
             // TODO: Implement exceptions.
-		    wp_die('<strong>' .__('You do not have permission to manage capabilities.', 'capsman-enhanced') . '</strong>');
-		}
+            wp_die('<strong>' . __('You do not have permission to manage capabilities.', 'capsman-enhanced') . '</strong>');
+        }
 
-		if ( 'POST' == $_SERVER['REQUEST_METHOD'] ) {
-			if ( empty($_REQUEST['SaveRole']) && empty($_REQUEST['AddCap']) ) {
-				check_admin_referer('capsman-general-manager');
-				$this->processAdminGeneral();
-			} elseif ( ! empty($_REQUEST['SaveRole']) ) {
-				ak_admin_notify( $this->message );  // moved update operation to earlier action to avoid UI refresh issues.  But outputting notification there breaks styling.
-			} elseif ( ! empty($_REQUEST['AddCap']) ) {
-				ak_admin_notify( $this->message );
-			}
-		} else {
-			if (!empty($_REQUEST['added'])) {
-				ak_admin_notify(__('New capability added to role.'));
-			}
-		}
+        if ('POST' == $_SERVER['REQUEST_METHOD']) {
+            if (empty($_REQUEST['SaveRole']) && empty($_REQUEST['AddCap'])) {
+                check_admin_referer('capsman-general-manager');
+                $this->processAdminGeneral();
+            } elseif (!empty($_REQUEST['SaveRole'])) {
+                ak_admin_notify($this->message);  // moved update operation to earlier action to avoid UI refresh issues.  But outputting notification there breaks styling.
+            } elseif (!empty($_REQUEST['AddCap'])) {
+                ak_admin_notify($this->message);
+            }
+        } else {
+            if (!empty($_REQUEST['added'])) {
+                ak_admin_notify(__('New capability added to role.'));
+            }
+        }
 
-		$this->generateNames();
-		$roles = array_keys($this->roles);
+        $this->generateNames();
+        $roles = array_keys($this->roles);
 
-		if ( isset($_GET['action']) && 'delete' == $_GET['action']) {
-			require_once( dirname(__FILE__).'/handler.php' );
-			$capsman_modify = new CapsmanHandler( $this );
-			$capsman_modify->adminDeleteRole();
-		}
+        if (isset($_GET['action']) && 'delete' == $_GET['action']) {
+            require_once(dirname(__FILE__) . '/handler.php');
+            $capsman_modify = new CapsmanHandler($this);
+            $capsman_modify->adminDeleteRole();
+        }
 
-		if ( ! isset($this->current) ) { // By default, we manage the default role
-			if (empty($_POST) && !empty($_REQUEST['role'])) {
-				$this->current = $_REQUEST['role'];
-			}
-		}
+        if (!isset($this->current)) { // By default, we manage the default role
+            if (empty($_POST) && !empty($_REQUEST['role'])) {
+                $this->current = $_REQUEST['role'];
+            }
+        }
 
-		if (!isset($this->current) || !get_role($this->current)) {
-			$this->current = get_option('default_role');
-		}
+        if (!isset($this->current) || !get_role($this->current)) {
+            $this->current = get_option('default_role');
+        }
 
-		if ( ! in_array($this->current, $roles) ) {    // Current role has been deleted.
-			$this->current = array_shift($roles);
-		}
+        if (!in_array($this->current, $roles)) {    // Current role has been deleted.
+            $this->current = array_shift($roles);
+        }
 
-		include ( dirname(CME_FILE) . '/includes/admin.php' );
-	}
+        include(dirname(CME_FILE) . '/includes/admin.php');
+    }
 
-	/**
-	 * Processes and saves the changes in the general capabilities form.
-	 *
-	 * @return void
-	 */
-	private function processAdminGeneral ()
-	{
-		if (! isset($_POST['action']) || 'update' != $_POST['action'] ) {
-		    // TODO: Implement exceptions. This must be a fatal error.
-			ak_admin_error(__('Bad form Received', 'capsman-enhanced'));
-			return;
-		}
+    /**
+     * Processes and saves the changes in the general capabilities form.
+     *
+     * @return void
+     */
+    private function processAdminGeneral()
+    {
+        if (!isset($_POST['action']) || 'update' != $_POST['action']) {
+            // TODO: Implement exceptions. This must be a fatal error.
+            ak_admin_error(__('Bad form Received', 'capsman-enhanced'));
+            return;
+        }
 
-		$post = stripslashes_deep($_POST);
-		if ( empty ($post['caps']) ) {
-		    $post['caps'] = array();
-		}
+        $post = stripslashes_deep($_POST);
+        if (empty ($post['caps'])) {
+            $post['caps'] = array();
+        }
 
-		$this->current = $post['current'];
+        $this->current = $post['current'];
 
-		// Select a new role.
-		if ( ! empty($post['LoadRole']) ) {
-			$this->current = $post['role'];
-		} else {
-			require_once( dirname(__FILE__).'/handler.php' );
-			$capsman_modify = new CapsmanHandler( $this );
-			$capsman_modify->processAdminGeneral( $post );
-		}
-	}
+        // Select a new role.
+        if (!empty($post['LoadRole'])) {
+            $this->current = $post['role'];
+        } else {
+            require_once(dirname(__FILE__) . '/handler.php');
+            $capsman_modify = new CapsmanHandler($this);
+            $capsman_modify->processAdminGeneral($post);
+        }
+    }
 
-	/**
-	 * Callback function to create names.
-	 * Replaces underscores by spaces and uppercases the first letter.
-	 *
-	 * @access private
-	 * @param string $cap Capability name.
-	 * @return string	The generated name.
-	 */
-	function _capNamesCB ( $cap )
-	{
-		$cap = str_replace('_', ' ', $cap);
-		//$cap = ucfirst($cap);
+    /**
+     * Callback function to create names.
+     * Replaces underscores by spaces and uppercases the first letter.
+     *
+     * @access private
+     * @param string $cap Capability name.
+     * @return string    The generated name.
+     */
+    function _capNamesCB($cap)
+    {
+        $cap = str_replace('_', ' ', $cap);
+        //$cap = ucfirst($cap);
 
-		return $cap;
-	}
+        return $cap;
+    }
 
-	/**
-	 * Generates an array with the system capability names.
-	 * The key is the capability and the value the created screen name.
-	 *
-	 * @uses self::_capNamesCB()
-	 * @return void
-	 */
-	function generateSysNames ()
-	{
-		$this->max_level = 10;
-		$this->roles = ak_get_roles(true);
-		$caps = array();
+    /**
+     * Generates an array with the system capability names.
+     * The key is the capability and the value the created screen name.
+     *
+     * @return void
+     * @uses self::_capNamesCB()
+     */
+    function generateSysNames()
+    {
+        $this->max_level = 10;
+        $this->roles = ak_get_roles(true);
+        $caps = array();
 
-		foreach ( array_keys($this->roles) as $role ) {
-			$role_caps = get_role($role);
-			$caps = array_merge( $caps, (array) $role_caps->capabilities );  // user reported PHP 5.3.3 error without array cast
-		}
+        foreach (array_keys($this->roles) as $role) {
+            $role_caps = get_role($role);
+            $caps = array_merge($caps, (array)$role_caps->capabilities);  // user reported PHP 5.3.3 error without array cast
+        }
 
-		$keys = array_keys($caps);
-		$names = array_map(array($this, '_capNamesCB'), $keys);
-		$this->capabilities = array_combine($keys, $names);
+        $keys = array_keys($caps);
+        $names = array_map(array($this, '_capNamesCB'), $keys);
+        $this->capabilities = array_combine($keys, $names);
 
-		asort($this->capabilities);
-	}
+        asort($this->capabilities);
+    }
 
-	/**
-	 * Generates an array with the user capability names.
-	 * If user has 'administrator' role, system roles are generated.
-	 * The key is the capability and the value the created screen name.
-	 * A user cannot manage more capabilities that has himself (Except for administrators).
-	 *
-	 * @uses self::_capNamesCB()
-	 * @return void
-	 */
-	function generateNames ()
-	{
-		if ( current_user_can('administrator') || ( is_multisite() && is_super_admin() ) ) {
-			$this->generateSysNames();
-		} else {
-		    global $user_ID;
-		    $user = new WP_User($user_ID);
-		    $this->max_level = ak_caps2level($user->allcaps);
+    /**
+     * Generates an array with the user capability names.
+     * If user has 'administrator' role, system roles are generated.
+     * The key is the capability and the value the created screen name.
+     * A user cannot manage more capabilities that has himself (Except for administrators).
+     *
+     * @return void
+     * @uses self::_capNamesCB()
+     */
+    function generateNames()
+    {
+        if (current_user_can('administrator') || (is_multisite() && is_super_admin())) {
+            $this->generateSysNames();
+        } else {
+            global $user_ID;
+            $user = new WP_User($user_ID);
+            $this->max_level = ak_caps2level($user->allcaps);
 
-		    $keys = array_keys($user->allcaps);
-    		$names = array_map(array($this, '_capNamesCB'), $keys);
+            $keys = array_keys($user->allcaps);
+            $names = array_map(array($this, '_capNamesCB'), $keys);
 
-	    	$this->capabilities = ( $keys ) ? array_combine($keys, $names) : array();
+            $this->capabilities = ($keys) ? array_combine($keys, $names) : array();
 
-		    $roles = ak_get_roles(true);
-    		unset($roles['administrator']);
+            $roles = ak_get_roles(true);
+            unset($roles['administrator']);
 
-			if ( ( defined( 'CME_LEGACY_USER_EDIT_FILTER' ) && CME_LEGACY_USER_EDIT_FILTER ) || ( ! empty( $_REQUEST['page'] ) && 'capsman' == $_REQUEST['page'] ) ) {
-				foreach ( $user->roles as $role ) {			// Unset the roles from capability list.
-					unset ( $this->capabilities[$role] );
-					unset ( $roles[$role]);					// User cannot manage his roles.
-				}
-			}
+            if ((defined('CME_LEGACY_USER_EDIT_FILTER') && CME_LEGACY_USER_EDIT_FILTER) || (!empty($_REQUEST['page']) && 'capsman' == $_REQUEST['page'])) {
+                foreach ($user->roles as $role) {            // Unset the roles from capability list.
+                    unset ($this->capabilities[$role]);
+                    unset ($roles[$role]);                    // User cannot manage his roles.
+                }
+            }
 
-	    	asort($this->capabilities);
+            asort($this->capabilities);
 
-		    foreach ( array_keys($roles) as $role ) {
-			    $r = get_role($role);
-    			$level = ak_caps2level($r->capabilities);
+            foreach (array_keys($roles) as $role) {
+                $r = get_role($role);
+                $level = ak_caps2level($r->capabilities);
 
-	    		if ( $level > $this->max_level ) {
-		    		unset($roles[$role]);
-			    }
-    		}
+                if ($level > $this->max_level) {
+                    unset($roles[$role]);
+                }
+            }
 
-	    	$this->roles = $roles;
-		}
-	}
+            $this->roles = $roles;
+        }
+    }
 
-	/**
-	 * Manages admin menu permission
-	 *
-	 * @hook add_management_page
-	 * @return void
-	 */
-	function pp_admin_menus ()
-	{
+    /**
+     * Manages navigation menu permission
+     *
+     * @hook add_management_page
+     * @return void
+     */
+    function pp_nav_menus()
+    {
 
 
-		if ((!is_multisite() || !is_super_admin()) && !current_user_can('administrator') && !current_user_can('manage_capabilities')) {
+        if ((!is_multisite() || !is_super_admin()) && !current_user_can('administrator') && !current_user_can('manage_capabilities')) {
             // TODO: Implement exceptions.
-		    wp_die('<strong>' .__('You do not have permission to manage admin menus.', 'capsman-enhanced') . '</strong>');
-		}
+            wp_die('<strong>' . __('You do not have permission to manage admin menus.', 'capsman-enhanced') . '</strong>');
+        }
 
-		$this->generateNames();
-		$roles = array_keys($this->roles);
+        $this->generateNames();
+        $roles = array_keys($this->roles);
 
-		if ( ! isset($this->current) ) {
-			if (empty($_POST) && !empty($_REQUEST['role'])) {
-				$this->current = $_REQUEST['role'];
-			}
-		}
+        if (!isset($this->current)) {
+            if (empty($_POST) && !empty($_REQUEST['role'])) {
+                $this->current = $_REQUEST['role'];
+            }
+        }
 
-		if (!isset($this->current) || !get_role($this->current)) {
-			$this->current = get_option('default_role');
-		}
+        if (!isset($this->current) || !get_role($this->current)) {
+            $this->current = get_option('default_role');
+        }
 
-		if ( ! in_array($this->current, $roles) ) {
-			$this->current = array_shift($roles);
-		}
+        if (!in_array($this->current, $roles)) {
+            $this->current = array_shift($roles);
+        }
 
-		$ppc_admin_menu_reload = '0';
 
-		if ( 'POST' == $_SERVER['REQUEST_METHOD'] && isset($_POST['ppc-admin-menu-role']) ) {
-			$this->current = $_POST['ppc-admin-menu-role'];
+        if ('POST' == $_SERVER['REQUEST_METHOD'] && isset($_POST['ppc-nav-menu-role'])) {
+            $this->current = $_POST['ppc-nav-menu-role'];
 
-			//set role admin menu
-			$admin_menu_option = !empty(get_option('capsman_admin_menus')) ? get_option('capsman_admin_menus') : [];
-			$admin_menu_option[$_POST['ppc-admin-menu-role']] = isset($_POST['pp_cababilities_disabled_menu']) ? $_POST['pp_cababilities_disabled_menu'] : '';
 
-			//set role admin child menu
-			$admin_child_menu_option = !empty(get_option('capsman_admin_child_menus')) ? get_option('capsman_admin_child_menus') : [];
-			$admin_child_menu_option[$_POST['ppc-admin-menu-role']] = isset($_POST['pp_cababilities_disabled_child_menu']) ? $_POST['pp_cababilities_disabled_child_menu'] : '';
+            //set role nav child menu
+            $nav_item_menu_option = !empty(get_option('capsman_nav_item_menus')) ? get_option('capsman_nav_item_menus') : [];
+            $nav_item_menu_option[$_POST['ppc-nav-menu-role']] = isset($_POST['pp_cababilities_restricted_items']) ? $_POST['pp_cababilities_restricted_items'] : '';
 
-			update_option('capsman_admin_menus', $admin_menu_option, false);
-			update_option('capsman_admin_child_menus', $admin_child_menu_option, false);
 
-			//set reload option for menu reflection if user is updating own role
-			if(in_array($_POST['ppc-admin-menu-role'], wp_get_current_user()->roles)){
-			$ppc_admin_menu_reload = '1';
-			}
+            update_option('capsman_nav_item_menus', $nav_item_menu_option, false);
+
 
             ak_admin_notify(__('Settings updated.', 'capsman-enhanced'));
-		}
+        }
 
-		include ( dirname(CME_FILE) . '/includes/admin-menus.php' );
+        include(dirname(CME_FILE) . '/includes/nav-menus.php');
 
-	}
+    }
 
-	/**
-	 * Manages backup, restore and resset roles and capabilities
-	 *
-	 * @hook add_management_page
-	 * @return void
-	 */
-	function backupTool ()
-	{
-		if ((!is_multisite() || !is_super_admin()) && !current_user_can('administrator') && !current_user_can('restore_roles')) {
-		    // TODO: Implement exceptions.
-			wp_die('<strong>' .__('You do not have permission to restore roles.', 'capsman-enhanced') . '</strong>');
-		}
+    /**
+     * Manages admin menu permission
+     *
+     * @hook add_management_page
+     * @return void
+     */
+    function pp_admin_menus()
+    {
 
-		if ( 'POST' == $_SERVER['REQUEST_METHOD'] ) {
-			require_once( dirname(__FILE__).'/backup-handler.php' );
-			$cme_backup_handler = new Capsman_BackupHandler( $this );
-			$cme_backup_handler->processBackupTool();
-		}
 
-		if ( isset($_GET['action']) && 'reset-defaults' == $_GET['action']) {
-			require_once( dirname(__FILE__).'/backup-handler.php' );
-			$cme_backup_handler = new Capsman_BackupHandler( $this );
-			$cme_backup_handler->backupToolReset();
-		}
+        if ((!is_multisite() || !is_super_admin()) && !current_user_can('administrator') && !current_user_can('manage_capabilities')) {
+            // TODO: Implement exceptions.
+            wp_die('<strong>' . __('You do not have permission to manage admin menus.', 'capsman-enhanced') . '</strong>');
+        }
 
-		include ( dirname(CME_FILE) . '/includes/backup.php' );
-	}
+        $this->generateNames();
+        $roles = array_keys($this->roles);
+
+        if (!isset($this->current)) {
+            if (empty($_POST) && !empty($_REQUEST['role'])) {
+                $this->current = $_REQUEST['role'];
+            }
+        }
+
+        if (!isset($this->current) || !get_role($this->current)) {
+            $this->current = get_option('default_role');
+        }
+
+        if (!in_array($this->current, $roles)) {
+            $this->current = array_shift($roles);
+        }
+
+        $ppc_admin_menu_reload = '0';
+
+        if ('POST' == $_SERVER['REQUEST_METHOD'] && isset($_POST['ppc-admin-menu-role'])) {
+            $this->current = $_POST['ppc-admin-menu-role'];
+
+            //set role admin menu
+            $admin_menu_option = !empty(get_option('capsman_admin_menus')) ? get_option('capsman_admin_menus') : [];
+            $admin_menu_option[$_POST['ppc-admin-menu-role']] = isset($_POST['pp_cababilities_disabled_menu']) ? $_POST['pp_cababilities_disabled_menu'] : '';
+
+            //set role admin child menu
+            $admin_child_menu_option = !empty(get_option('capsman_admin_child_menus')) ? get_option('capsman_admin_child_menus') : [];
+            $admin_child_menu_option[$_POST['ppc-admin-menu-role']] = isset($_POST['pp_cababilities_disabled_child_menu']) ? $_POST['pp_cababilities_disabled_child_menu'] : '';
+
+            update_option('capsman_admin_menus', $admin_menu_option, false);
+            update_option('capsman_admin_child_menus', $admin_child_menu_option, false);
+
+            //set reload option for menu reflection if user is updating own role
+            if (in_array($_POST['ppc-admin-menu-role'], wp_get_current_user()->roles)) {
+                $ppc_admin_menu_reload = '1';
+            }
+
+            ak_admin_notify(__('Settings updated.', 'capsman-enhanced'));
+        }
+
+        include(dirname(CME_FILE) . '/includes/admin-menus.php');
+
+    }
+
+    /**
+     * Manages backup, restore and resset roles and capabilities
+     *
+     * @hook add_management_page
+     * @return void
+     */
+    function backupTool()
+    {
+        if ((!is_multisite() || !is_super_admin()) && !current_user_can('administrator') && !current_user_can('restore_roles')) {
+            // TODO: Implement exceptions.
+            wp_die('<strong>' . __('You do not have permission to restore roles.', 'capsman-enhanced') . '</strong>');
+        }
+
+        if ('POST' == $_SERVER['REQUEST_METHOD']) {
+            require_once(dirname(__FILE__) . '/backup-handler.php');
+            $cme_backup_handler = new Capsman_BackupHandler($this);
+            $cme_backup_handler->processBackupTool();
+        }
+
+        if (isset($_GET['action']) && 'reset-defaults' == $_GET['action']) {
+            require_once(dirname(__FILE__) . '/backup-handler.php');
+            $cme_backup_handler = new Capsman_BackupHandler($this);
+            $cme_backup_handler->backupToolReset();
+        }
+
+        include(dirname(CME_FILE) . '/includes/backup.php');
+    }
 }
 
-function cme_publishpressFooter() {
-	?>
-	<footer>
+function cme_publishpressFooter()
+{
+    ?>
+    <footer>
 
-	<div class="pp-rating">
-	<a href="https://wordpress.org/support/plugin/capability-manager-enhanced/reviews/#new-post" target="_blank" rel="noopener noreferrer">
-	<?php printf(
-		__('If you like %s, please leave us a %s rating. Thank you!', 'capsman-enhanced'),
-		'<strong>PublishPress Capabilities</strong>',
-		'<span class="dashicons dashicons-star-filled"></span><span class="dashicons dashicons-star-filled"></span><span class="dashicons dashicons-star-filled"></span><span class="dashicons dashicons-star-filled"></span><span class="dashicons dashicons-star-filled"></span>'
-		);
-	?>
-	</a>
-	</div>
+        <div class="pp-rating">
+            <a href="https://wordpress.org/support/plugin/capability-manager-enhanced/reviews/#new-post" target="_blank"
+               rel="noopener noreferrer">
+                <?php printf(
+                    __('If you like %s, please leave us a %s rating. Thank you!', 'capsman-enhanced'),
+                    '<strong>PublishPress Capabilities</strong>',
+                    '<span class="dashicons dashicons-star-filled"></span><span class="dashicons dashicons-star-filled"></span><span class="dashicons dashicons-star-filled"></span><span class="dashicons dashicons-star-filled"></span><span class="dashicons dashicons-star-filled"></span>'
+                );
+                ?>
+            </a>
+        </div>
 
-	<hr>
-	<nav>
-	<ul>
-	<li><a href="https://publishpress.com/capability-manager/" target="_blank" rel="noopener noreferrer" title="<?php _e('About PublishPress Capabilities', 'capsman-enhanced');?>"><?php _e('About', 'capsman-enhanced');?>
-	</a></li>
-	<li><a href="https://publishpress.com/knowledge-base/how-to-use-capability-manager/" target="_blank" rel="noopener noreferrer" title="<?php _e('Capabilites Documentation', 'capsman-enhanced');?>"><?php _e('Documentation', 'capsman-enhanced');?>
-	</a></li>
-	<li><a href="https://publishpress.com/contact" target="_blank" rel="noopener noreferrer" title="<?php _e('Contact the PublishPress team', 'capsman-enhanced');?>"><?php _e('Contact', 'capsman-enhanced');?>
-	</a></li>
-	<li><a href="https://twitter.com/publishpresscom" target="_blank" rel="noopener noreferrer"><span class="dashicons dashicons-twitter"></span>
-	</a></li>
-	<li><a href="https://facebook.com/publishpress" target="_blank" rel="noopener noreferrer"><span class="dashicons dashicons-facebook"></span>
-	</a></li>
-	</ul>
-	</nav>
+        <hr>
+        <nav>
+            <ul>
+                <li><a href="https://publishpress.com/capability-manager/" target="_blank" rel="noopener noreferrer"
+                       title="<?php _e('About PublishPress Capabilities', 'capsman-enhanced'); ?>"><?php _e('About', 'capsman-enhanced'); ?>
+                    </a></li>
+                <li><a href="https://publishpress.com/knowledge-base/how-to-use-capability-manager/" target="_blank"
+                       rel="noopener noreferrer"
+                       title="<?php _e('Capabilites Documentation', 'capsman-enhanced'); ?>"><?php _e('Documentation', 'capsman-enhanced'); ?>
+                    </a></li>
+                <li><a href="https://publishpress.com/contact" target="_blank" rel="noopener noreferrer"
+                       title="<?php _e('Contact the PublishPress team', 'capsman-enhanced'); ?>"><?php _e('Contact', 'capsman-enhanced'); ?>
+                    </a></li>
+                <li><a href="https://twitter.com/publishpresscom" target="_blank" rel="noopener noreferrer"><span
+                                class="dashicons dashicons-twitter"></span>
+                    </a></li>
+                <li><a href="https://facebook.com/publishpress" target="_blank" rel="noopener noreferrer"><span
+                                class="dashicons dashicons-facebook"></span>
+                    </a></li>
+            </ul>
+        </nav>
 
-	<div class="pp-pressshack-logo">
-	<a href="https://publishpress.com" target="_blank" rel="noopener noreferrer">
+        <div class="pp-pressshack-logo">
+            <a href="https://publishpress.com" target="_blank" rel="noopener noreferrer">
 
-	<img src="<?php echo plugins_url('', CME_FILE) . '/common/img/publishpress-logo.png';?>" />
-	</a>
-	</div>
+                <img src="<?php echo plugins_url('', CME_FILE) . '/common/img/publishpress-logo.png'; ?>"/>
+            </a>
+        </div>
 
-	</footer>
-	<?php
+    </footer>
+    <?php
 }

--- a/includes/nav-menus.php
+++ b/includes/nav-menus.php
@@ -1,0 +1,367 @@
+<?php
+/**
+ * Capability Manager Nav Menus Permission.
+ * Nav menus permission and visibility per roles.
+ *
+ *    Copyright 2020, PublishPress <help@publishpress.com>
+ *
+ *    This program is free software; you can redistribute it and/or
+ *    modify it under the terms of the GNU General Public License
+ *    version 2 as published by the Free Software Foundation.
+ *
+ *    This program is distributed in the hope that it will be useful,
+ *    but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *    GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+global $capsman;
+$roles = $this->roles;
+$default_role = $this->current;
+
+
+//add logged in and guest option
+$ppc_other_permissions = array("ppc_users" => __('Logged In Users', 'capsman-enhanced'), "ppc_guest" => __('Logged Out Users', 'capsman-enhanced'));
+
+if (!empty($_REQUEST['role'])) {
+
+    if (array_key_exists($_REQUEST['role'], $ppc_other_permissions)) {
+        $default_role = $_REQUEST['role'];
+        $role_caption = $ppc_other_permissions[$_REQUEST['role']];
+    } else {
+        $role_caption = translate_user_role($roles[$default_role]);
+    }
+
+} else {
+    $role_caption = translate_user_role($roles[$default_role]);
+}
+
+
+$nav_menus = (array)get_terms('nav_menu');
+$nav_menus = array_combine(wp_list_pluck($nav_menus, 'term_id'), wp_list_pluck($nav_menus, 'name'));
+
+
+$nav_menu_item_option = !empty(get_option('capsman_nav_item_menus')) ? get_option('capsman_nav_item_menus') : [];
+$nav_menu_item_option = array_key_exists($default_role, $nav_menu_item_option) ? (array)$nav_menu_item_option[$default_role] : [];
+
+?>
+
+
+    <div class="wrap publishpress-caps-manage pressshack-admin-wrapper pp-capability-menus-wrapper">
+        <div id="icon-capsman-admin" class="icon32"></div>
+        <h2><?php _e('Navigation Menus Permission', 'capsman-enhanced'); ?></h2>
+
+        <form method="post" id="ppc-nav-menu-form" action="admin.php?page=<?php echo $this->ID ?>-pp-nav-menus">
+            <?php wp_nonce_field('capsman-pp-nav-menus'); ?>
+
+            <fieldset>
+                <table id="akmin">
+                    <tr>
+                        <td class="content">
+
+                            <dl>
+                                <dt><?php printf(__('Nav Menus Permission for %s', 'capsman-enhanced'), $role_caption); ?></dt>
+
+                                <dd>
+                                    <div class="publishpress-headline">
+                                    <span class="cme-subtext">
+                                    <strong><?php _e('Note', 'capsman-enhanced'); ?>:</strong>
+                                    <?php _e('This feature only remove menu from navigation and prevent access to the menu page if it\'s not custom menu link for the restricted roles and users.', 'capsman-enhanced'); ?>
+                                    </span>
+                                    </div>
+                                </dd>
+
+                                <table width='100%' class="form-table">
+                                    <tr>
+                                        <td>
+                                            <select name="ppc-nav-menu-role" class="ppc-nav-menu-role">
+                                                <optgroup label="Users">
+                                                    <?php
+                                                    foreach ($ppc_other_permissions as $p_value => $p_title) {
+                                                        ?>
+                                                        <option value="<?php echo $p_value; ?>" <?php selected($default_role, $p_value); ?>> <?php echo $p_title; ?>
+                                                            &nbsp;
+                                                        </option>
+                                                    <?php }
+                                                    ?>
+                                                </optgroup>
+
+                                                <optgroup label="Roles">
+                                                    <?php
+                                                    foreach ($roles as $role => $name) {
+                                                        $name = translate_user_role($name);
+                                                        ?>
+                                                        <option value="<?php echo $role; ?>" <?php selected($default_role, $role); ?>> <?php echo $name; ?>
+                                                            &nbsp;
+                                                        </option>
+                                                    <?php } ?>
+                                                </optgroup>
+
+                                            </select> &nbsp;
+
+                                        <td>
+                                            <div style="float:right">
+                                                <input type="submit" name="nav-menu-submit"
+                                                       value="<?php _e('Save Changes', 'capsman-enhanced') ?>"
+                                                       class="button-primary ppc-nav-menu-submit"/> &nbsp;
+                                            </div>
+                                        </td>
+                                        </td>
+                                    </tr>
+                                </table>
+
+                                <div id="pp-capability-menu-wrapper" class="postbox">
+                                    <div class="pp-capability-menus">
+
+                                        <div class="pp-capability-menus-wrap">
+                                            <div id="pp-capability-menus-general"
+                                                 class="pp-capability-menus-content editable-role"
+                                                 style="display: block;">
+
+                                                <table class="wp-list-table widefat fixed pp-capability-menus-select">
+
+                                                    <thead>
+                                                    <tr>
+                                                        <th class="menu-column"><?php _e('Menu', 'capsman-enhanced') ?></th>
+                                                        <th class="restrict-column"><?php _e('Restrict', 'capsman-enhanced') ?></th>
+                                                    </tr>
+                                                    </thead>
+
+                                                    <tfoot>
+                                                    <tr>
+                                                        <th class="menu-column"><?php _e('Menu', 'capsman-enhanced') ?></th>
+                                                        <th class="restrict-column"><?php _e('Restrict', 'capsman-enhanced') ?></th>
+                                                    </tr>
+                                                    </tfoot>
+
+                                                    <tbody>
+                                                    <tr class="ppc-menu-row parent-menu">
+
+                                                        <td class="menu-column ppc-menu-item">
+                                                            <label for="check-all-item">
+                                                        <span class="menu-item-link check-all-menu-link">
+                                                            <strong><i class="dashicons dashicons-leftright"></i>
+                                                            <?php _e('Toggle all', 'capsman-enhanced'); ?>
+                                                            </strong>
+                                                        </span></label>
+                                                        </td>
+
+                                                        <td class="restrict-column ppc-menu-checkbox">
+                                                            <input id="check-all-item"
+                                                                   class="check-item check-all-menu-item"
+                                                                   type="checkbox"/>
+                                                        </td>
+
+                                                    </tr>
+
+                                                    <?php
+
+                                                    if (count($nav_menus) > 0) {
+
+                                                        $sn = 0;
+                                                        foreach ($nav_menus as $menu_id => $menu_name) {
+                                                            ?>
+
+                                                            <tr class="ppc-menu-row parent-menu">
+
+                                                                <td class="menu-column ppc-menu-item parent">
+
+                                                                    <label for="check-item-<?php echo $sn; ?>">
+                                                                    <span class="menu-item-link">
+                                                                    <strong><i class="dashicons dashicons-arrow-right"></i>
+                                                                        <?php echo strip_tags($menu_name); ?>
+                                                                    </strong></span>
+                                                                    </label>
+                                                                </td>
+
+                                                                <td class="restrict-column ppc-menu-checkbox">
+
+                                                                </td>
+
+                                                            </tr>
+
+                                                            <?php
+                                                            //begin menu item query
+                                                            $menu_items = (array)wp_get_nav_menu_items($menu_id);
+
+                                                            if (count($menu_items) === 0) {
+                                                                continue;
+                                                            }
+
+                                                            foreach ($menu_items as $menu_item) {
+                                                                $sn++;
+
+                                                                $sub_menu_value = $menu_item->ID . '_' . $menu_item->object_id . '_' . $menu_item->object;
+                                                                /**
+                                                                 * 1.) Item ID
+                                                                 * 2.) Object Id
+                                                                 * 3.) Object (e.g, category)
+                                                                 * object as last as it can contain underscore
+                                                                 */
+
+                                                                if ($menu_item->menu_item_parent > 0) {
+                                                                    $depth_space = '&nbsp;&nbsp;&nbsp; &nbsp;&nbsp;&nbsp; &bull;';
+                                                                } else {
+                                                                    $depth_space = '&nbsp;&nbsp;&nbsp; &#x25cf;';
+                                                                }
+                                                                ?>
+                                                                <tr class="ppc-menu-row child-menu">
+
+                                                                    <td class="menu-column ppc-menu-item'">
+
+                                                                        <label for="check-item-<?php echo $sn; ?>">
+                                                                        <span class="menu-item-link<?php echo (in_array($sub_menu_value, $nav_menu_item_option)) ? ' restricted' : ''; ?>">
+                                                                        <strong><?php echo $depth_space; ?>
+                                                                            <?php echo strip_tags($menu_item->title); ?>
+                                                                        </strong></span>
+                                                                        </label>
+
+                                                                    </td>
+
+                                                                    <td class="restrict-column ppc-menu-checkbox">
+                                                                        <input id="check-item-<?php echo $sn; ?>"
+                                                                               class="check-item" type="checkbox"
+                                                                               name="pp_cababilities_restricted_items[]"
+                                                                               value="<?php echo $sub_menu_value; ?>"
+                                                                            <?php echo (in_array($sub_menu_value, $nav_menu_item_option)) ? 'checked' : ''; ?> />
+                                                                    </td>
+
+                                                                </tr>
+                                                                <?php
+                                                            }  // end foreach menu_items
+
+                                                            $sn++;
+
+                                                        } // end foreach nav_menus
+
+                                                    } else {
+                                                        ?>
+                                                        <tr>
+                                                            <td style="color: red;"> <?php _e('No menu found', 'capsman-enhanced'); ?></td>
+                                                        </tr>
+                                                        <?php
+                                                    }
+
+                                                    ?>
+                                                    <tr class="ppc-menu-row parent-menu">
+
+                                                        <td class="menu-column ppc-menu-item">
+                                                            <label for="check-all-item-2">
+                                                            <span class="menu-item-link check-all-menu-link">
+                                                            <strong>
+                                                                <i class="dashicons dashicons-leftright"></i>
+                                                                <?php _e('Toggle all', 'capsman-enhanced'); ?>
+                                                            </strong>
+                                                            </span>
+                                                            </label>
+                                                        </td>
+
+                                                        <td class="restrict-column ppc-menu-checkbox">
+                                                            <input id="check-all-item-2"
+                                                                   class="check-item check-all-menu-item"
+                                                                   type="checkbox"/>
+                                                        </td>
+
+                                                    </tr>
+
+                                                    </tbody>
+                                                </table>
+                                            </div>
+
+                                        </div>
+                                    </div>
+                                </div>
+
+                                <input type="submit" name="nav-menu-submit"
+                                       value="<?php _e('Save Changes', 'capsman-enhanced') ?>"
+                                       class="button-primary ppc-nav-menu-submit"/> &nbsp;
+
+                            </dl>
+
+                        </td>
+                    </tr>
+                </table>
+
+            </fieldset>
+
+        </form>
+
+        <script type="text/javascript">
+            /* <![CDATA[ */
+            jQuery(document).ready(function ($) {
+
+                // -------------------------------------------------------------
+                //   Set form action attribute to include role
+                // -------------------------------------------------------------
+                $('#ppc-nav-menu-form').attr('action', '<?php echo admin_url('admin.php?page=' . $this->ID . '-pp-nav-menus&role=' . $default_role . ''); ?>');
+
+                // -------------------------------------------------------------
+                //   Instant restricted item class
+                // -------------------------------------------------------------
+                $(document).on('change', '.pp-capability-menus-wrapper .ppc-menu-row .check-item', function () {
+
+                    if ($(this).is(':checked')) {
+                        //add class if value is checked
+                        $(this).parent().parent().find('.menu-item-link').addClass('restricted');
+
+                        //toggle all checkbox
+                        if ($(this).hasClass('check-all-menu-item')) {
+                            $("input[type='checkbox'][name='pp_cababilities_restricted_nav[]']").prop('checked', true);
+                            $("input[type='checkbox'][name='pp_cababilities_restricted_items[]']").prop('checked', true);
+                            $('.menu-item-link').addClass('restricted');
+                        } else {
+                            $('.check-all-menu-link').removeClass('restricted');
+                            $('.check-all-menu-item').prop('checked', false);
+                        }
+
+                    } else {
+                        //unchecked value
+                        $(this).parent().parent().find('.menu-item-link').removeClass('restricted');
+
+                        //toggle all checkbox
+                        if ($(this).hasClass('check-all-menu-item')) {
+                            $("input[type='checkbox'][name='pp_cababilities_restricted_nav[]']").prop('checked', false);
+                            $("input[type='checkbox'][name='pp_cababilities_restricted_items[]']").prop('checked', false);
+                            $('.menu-item-link').removeClass('restricted');
+                        } else {
+                            $('.check-all-menu-link').removeClass('restricted');
+                            $('.check-all-menu-item').prop('checked', false);
+                        }
+
+                    }
+
+                });
+
+                // -------------------------------------------------------------
+                //   Load selected roles menu
+                // -------------------------------------------------------------
+                $(document).on('change', '.pp-capability-menus-wrapper .ppc-nav-menu-role', function () {
+
+                    //disable select
+                    $('.pp-capability-menus-wrapper .ppc-nav-menu-role').attr('disabled', true);
+
+                    //hide button
+                    $('.pp-capability-menus-wrapper .ppc-nav-menu-submit').hide();
+
+                    //show loading
+                    $('#pp-capability-menu-wrapper').html('<img src="<?php echo $capsman->mod_url; ?>/images/loader-black.gif" alt="loading...">');
+
+                    //go to url
+                    window.location = '<?php echo admin_url('admin.php?page=' . $this->ID . '-pp-nav-menus&role='); ?>' + $(this).val() + '';
+
+                });
+
+            });
+            /* ]]> */
+        </script>
+
+
+        <?php if (!defined('PUBLISHPRESS_CAPS_PRO_VERSION') || get_option('cme_display_branding')) {
+            cme_publishpressFooter();
+        }
+        ?>
+    </div>
+<?php


### PR DESCRIPTION
As previously discussed, this features is not limited to roles alone but also extend option to set navigation menu permission for 'logged in users' or 'logged out users(Guest)' as a whole.

Apart from removing the restricted menu from the site nav bar, it also block access to the menu page if it's a post, page, cpt(any custom type post), categories, tags or any taxonomies.

![Screenshot 2020-11-11 at 22 53 07](https://user-images.githubusercontent.com/46832636/98874147-f1204a00-2479-11eb-9825-fab96176bc4c.png)
![Screenshot 2020-11-11 at 22 54 37](https://user-images.githubusercontent.com/46832636/98874156-f54c6780-2479-11eb-997b-366b6e4ebb0d.png)
