### PR TITLE
Pro: bbPress capabilities were not included in post capabilities grid

### DIFF
--- a/includes/admin.php
+++ b/includes/admin.php
@@ -235,8 +235,12 @@ if( defined('PRESSPERMIT_ACTIVE') ) {
 				$defined['type'] = apply_filters('cme_filterable_post_types', get_post_types( array( 'public' => true, 'show_ui' => true), 'object', 'or' ));
 				$defined['taxonomy'] = get_taxonomies( array( 'public' => true ), 'object' );
 				
-				$unfiltered['type'] = apply_filters( 'pp_unfiltered_post_types', array( 'forum','topic','reply','wp_block' ) );  // bbPress' dynamic role def requires additional code to enforce stored caps
-				$unfiltered['taxonomy'] = apply_filters( 'pp_unfiltered_taxonomies', array( 'post_status', 'topic-tag' ) );  // avoid confusion with Edit Flow administrative taxonomy
+				// bbPress' dynamic role def requires additional code to enforce stored caps
+				$unfiltered['type'] = apply_filters('presspermit_unfiltered_post_types', ['forum','topic','reply','wp_block']);
+				$unfiltered['type'] = (defined('PP_CAPABILITIES_NO_LEGACY_FILTERS')) ? $unfiltered['type'] : apply_filters('pp_unfiltered_post_types', $unfiltered['type']);
+				
+				$unfiltered['taxonomy'] = apply_filters('presspermit_unfiltered_post_types', ['post_status', 'topic-tag']);  // avoid confusion with Edit Flow administrative taxonomy
+				$unfiltered['taxonomy'] = (defined('PP_CAPABILITIES_NO_LEGACY_FILTERS')) ? $unfiltered['taxonomy'] : apply_filters('pp_unfiltered_post_types', $unfiltered['taxonomy']);
 				
 				$enabled_taxonomies = cme_get_assisted_taxonomies();
 				

--- a/includes/filters.php
+++ b/includes/filters.php
@@ -243,7 +243,10 @@ function cme_get_assisted_post_types() {
 	
 	$post_types = get_post_types( $type_args, 'names', 'or' );
 	
-	if ( $omit_types = apply_filters( 'pp_unfiltered_post_types', array('forum', 'topic', 'reply', 'wp_block', 'customize_changeset') ) ) {
+	$omit_types = apply_filters('presspermit_unfiltered_post_types', ['forum', 'topic', 'reply', 'wp_block', 'customize_changeset']);
+	$omit_types = (defined('PP_CAPABILITIES_NO_LEGACY_FILTERS')) ? $omit_types : apply_filters('pp_unfiltered_post_types', $omit_types);
+
+	if ($omit_types) {
 		$post_types = array_diff_key( $post_types, array_fill_keys( (array) $omit_types, true ) );
 	}
 	

--- a/includes/pp-ui.php
+++ b/includes/pp-ui.php
@@ -108,8 +108,12 @@ class Capsman_PP_UI {
 				
 				echo "<table style='width:100%'><tr>";
 				
-				$unfiltered = apply_filters( 'pp_unfiltered_post_types', array('forum','topic','reply','wp_block', 'customize_changeset') );			// bbPress' dynamic role def requires additional code to enforce stored caps
-				$hidden = apply_filters( 'pp_hidden_post_types', array() );
+				// bbPress' dynamic role def requires additional code to enforce stored caps
+				$unfiltered = apply_filters('presspermit_unfiltered_post_types', ['forum','topic','reply','wp_block', 'customize_changeset']);
+				$unfiltered = (defined('PP_CAPABILITIES_NO_LEGACY_FILTERS')) ? $unfiltered : apply_filters('pp_unfiltered_post_types', $unfiltered);  // maintain legacy filter to support custom code
+				
+				$hidden = apply_filters('presspermit_hidden_post_types', []); 
+				$hidden = apply_filters('pp_hidden_post_types', $hidden);  // maintain legacy filter to support custom code
 				
 				echo '<td style="width:50%">';
 				


### PR DESCRIPTION
This fix reinstates the effect of the Permissions Pro Compatibility Pack module in causing Forum, Topic and Reply permissions to be included in the post capabilities grid.