### PR TITLE
Remove ppma_edit_orphan_post, status_change capabilities

### DIFF
--- a/includes/admin.php
+++ b/includes/admin.php
@@ -631,12 +631,10 @@ if( defined('PRESSPERMIT_ACTIVE') ) {
 						array(
 						'edit_metadata',
 						'edit_post_subscriptions',
-						'ppma_edit_orphan_post',
 						'pp_manage_roles',
 						'pp_set_notification_channel',
 						'pp_view_calendar',
 						'pp_view_content_overview',
-						'status_change',
 						)
 					);
 				}


### PR DESCRIPTION
These capabilities are no longer used by PublishPress.