### PR TITLE
Retain last role selection instead of defaulting each screen to Subscriber

### DIFF
--- a/includes/features/editor-features.php
+++ b/includes/features/editor-features.php
@@ -22,7 +22,8 @@ require_once (dirname(CME_FILE) . '/includes/features/restrict-editor-features.p
 
 global $capsman;
 $roles = $capsman->roles;
-$default_role = $capsman->current;
+
+$default_role = $capsman->get_last_role();
 
 $classic_editor = pp_capabilities_is_classic_editor_available();
 ?>

--- a/includes/handler.php
+++ b/includes/handler.php
@@ -26,7 +26,7 @@ class CapsmanHandler
 		if ( ! empty($post['CreateRole']) ) {
 			if ( $newrole = $this->createRole($post['create-name']) ) {
 				ak_admin_notify(__('New role created.', 'capsman-enhanced'));
-				$this->cm->current = $newrole;
+				$this->cm->set_current_role($newrole);
 			} else {
 				if ( empty($post['create-name']) && in_array(get_locale(), ['en_EN', 'en_US']) )
 					ak_admin_error( 'Error: No role name specified.', 'capsman-enhanced' );
@@ -45,14 +45,14 @@ class CapsmanHandler
 				update_option($wp_roles->role_key, $wp_roles->roles);
 
 				ak_admin_notify(sprintf(__('Role "%s" (id %s) renamed to "%s"', 'capsman-enhanced'), $old_title, strtolower($current->name), $new_title));
-				$this->cm->current = $current->name;
+				$this->cm->set_current_role($current->name);
 			}
 		// Copy current role to a new one.
 		} elseif ( ! empty($post['CopyRole']) ) {
 			$current = get_role($post['current']);
 			if ( $newrole = $this->createRole($post['copy-name'], $current->capabilities) ) {
 				ak_admin_notify(__('New role created.', 'capsman-enhanced'));
-				$this->cm->current = $newrole;
+				$this->cm->set_current_role($newrole);
 			} else {
 				if ( empty($post['copy-name']) && in_array(get_locale(), ['en_EN', 'en_US']) )
 					ak_admin_error( 'Error: No role name specified.', 'capsman-enhanced' );


### PR DESCRIPTION
The last role selection by the current user is stored to the options table.