### PR TITLE
Prevent PHP Notice for invalid Ajax request

### DIFF
--- a/includes/admin-load.php
+++ b/includes/admin-load.php
@@ -58,7 +58,7 @@ class PP_Capabilities_Admin_UI {
             global $pagenow;
 
             if ((($pagenow == 'admin.php') && isset($_GET['page']) && in_array($_GET['page'], ['pp-capabilities', 'pp-capabilities-roles', 'pp-capabilities-backup'])) // @todo: CSS for button alignment in Editor Features, Admin Features
-            || (defined('DOING_AJAX') && DOING_AJAX && (false !== strpos($_REQUEST['action'], 'capability-manager-enhanced')))
+            || (defined('DOING_AJAX') && DOING_AJAX && !empty($_REQUEST['action']) && (false !== strpos($_REQUEST['action'], 'capability-manager-enhanced')))
             ) {
                 if (!class_exists('\PublishPress\WordPressReviews\ReviewsController')) {
                     include_once PUBLISHPRESS_CAPS_ABSPATH . '/vendor/publishpress/wordpress-reviews/ReviewsController.php';


### PR DESCRIPTION
Fixes #237

Ajax requests without an action argument are invalid, but we need to prevent malicious requests from creating error log entries.