### PR TITLE
Output variable escaping

### DIFF
--- a/capsman-enhanced.php
+++ b/capsman-enhanced.php
@@ -37,7 +37,7 @@ if (!defined('CAPSMAN_VERSION')) {
 foreach (get_option('active_plugins') as $plugin_file) {
 	if ( false !== strpos($plugin_file, 'capsman.php') ) {
 		add_action('admin_notices', function() {
-			$message = __( '<strong>Error:</strong> PublishPress Capabilities cannot function because another copy of Capability Manager is active.', 'capsman-enhanced' );
+			$message = esc_html__( '<strong>Error:</strong> PublishPress Capabilities cannot function because another copy of Capability Manager is active.', 'capsman-enhanced' );
 			echo '<div id="message" class="error fade" style="color: black">' . $message . '</div>';
 		});
 		return;
@@ -68,7 +68,7 @@ if ($pro_active) {
         function($links, $file)
         {
             if ($file == plugin_basename(__FILE__)) {
-                $links[]= __('<strong>This plugin can be deleted.</strong>', 'press-permit-core');
+                $links[]= esc_html__('<strong>This plugin can be deleted.</strong>', 'press-permit-core');
             }
 
             return $links;
@@ -95,10 +95,10 @@ if ( version_compare(PHP_VERSION, '5.4.0', '<') ) {
 		$data = get_plugin_data(__FILE__);
 		load_plugin_textdomain('capsman-enhanced', false, basename(dirname(__FILE__)) .'/languages');
 
-		echo '<div class="error"><p><strong>' . __('Warning:', 'capsman-enhanced') . '</strong> '
-			. sprintf(__('The active plugin %s is not compatible with your PHP version.', 'capsman-enhanced') .'</p><p>',
-				'&laquo;' . $data['Name'] . ' ' . $data['Version'] . '&raquo;')
-			. sprintf(__('%s is required for this plugin.', 'capsman-enhanced'), 'PHP-5 ')
+		echo '<div class="error"><p><strong>' . esc_html__('Warning:', 'capsman-enhanced') . '</strong> '
+			. sprintf(esc_html__('The active plugin %s is not compatible with your PHP version.', 'capsman-enhanced') .'</p><p>',
+				'&laquo;' . esc_html($data['Name']) . ' ' . esc_html($data['Version']) . '&raquo;')
+			. sprintf(esc_html__('%s is required for this plugin.', 'capsman-enhanced'), 'PHP-5 ')
 			. '</p></div>';
 	});
 } else {

--- a/framework/lib/formating.php
+++ b/framework/lib/formating.php
@@ -37,9 +37,9 @@ function ak_admin_notify( $message = '' )
 {
     if (is_admin() && !did_action('pp_capabilities_error')) {
 	    if ( empty($message) ) {
-		    $message = __('Settings saved.', 'capsman-enhanced');
+		    $message = esc_html__('Settings saved.', 'capsman-enhanced');
     	}
-    	echo '<div id="message" class="updated fade"><p><strong>' . $message . '</strong></p></div>';
+    	echo '<div id="message" class="updated fade"><p><strong>' . esc_html($message) . '</strong></p></div>';
     }
 }
 
@@ -52,7 +52,7 @@ function ak_admin_notify( $message = '' )
 function ak_admin_error( $message )
 {
     if ( is_admin() ) {
-        echo '<div id="error" class="error"><p><strong>' . $message . '</strong></p></div>';
+        echo '<div id="error" class="error"><p><strong>' . esc_html($message) . '</strong></p></div>';
     }
 
     do_action('pp_capabilities_error');

--- a/includes-core/CoreAdmin.php
+++ b/includes-core/CoreAdmin.php
@@ -59,8 +59,8 @@ class CoreAdmin {
     function actCapabilitiesSubmenus() {
         $cap_name = (is_multisite() && is_super_admin()) ? 'read' : 'manage_capabilities';
         
-        add_submenu_page('pp-capabilities',  __('Admin Menus', 'capsman-enhanced'), __('Admin Menus', 'capsman-enhanced'), $cap_name, 'pp-capabilities-admin-menus', [$this, 'AdminMenusPromo']);
-        add_submenu_page('pp-capabilities',  __('Nav Menus', 'capsman-enhanced'), __('Nav Menus', 'capsman-enhanced'), $cap_name, 'pp-capabilities-nav-menus', [$this, 'NavMenusPromo']);
+        add_submenu_page('pp-capabilities',  esc_html__('Admin Menus', 'capsman-enhanced'), esc_html__('Admin Menus', 'capsman-enhanced'), $cap_name, 'pp-capabilities-admin-menus', [$this, 'AdminMenusPromo']);
+        add_submenu_page('pp-capabilities',  esc_html__('Nav Menus', 'capsman-enhanced'), esc_html__('Nav Menus', 'capsman-enhanced'), $cap_name, 'pp-capabilities-nav-menus', [$this, 'NavMenusPromo']);
     }
 
     function AdminMenusPromo() {

--- a/includes-core/admin-features-promo.php
+++ b/includes-core/admin-features-promo.php
@@ -71,12 +71,12 @@
    <td colspan="2">
       <div class="pp-promo-upgrade-notice">
          <p>
-            <?php _e('You can block pages by URL or hide Admin elements by entering a CSS class or ID. This feature is available in PublishPress Capabilities Pro.',
+            <?php esc_html_e('You can block pages by URL or hide Admin elements by entering a CSS class or ID. This feature is available in PublishPress Capabilities Pro.',
                'capsman-enhanced'); ?>
          </p>
          <p>
             <a href="https://publishpress.com/links/capabilities-banner" target="_blank">
-            <?php _e('Upgrade to Pro', 'capsman-enhanced'); ?>
+            <?php esc_html_e('Upgrade to Pro', 'capsman-enhanced'); ?>
             </a>
          </p>
       </div>

--- a/includes-core/admin-menus-promo.php
+++ b/includes-core/admin-menus-promo.php
@@ -26,7 +26,7 @@ $default_role = $capsman->current;
 
 <div class="wrap publishpress-caps-manage pressshack-admin-wrapper pp-capability-menus-wrapper-promo">
     <div id="icon-capsman-admin" class="icon32"></div>
-    <h2><?php _e('Admin Menu Restrictions', 'capsman-enhanced'); ?></h2>
+    <h2><?php esc_html_e('Admin Menu Restrictions', 'capsman-enhanced'); ?></h2>
 
     <form method="post" id="ppc-admin-menu-form" action="admin.php?page=pp-capabilities-admin-menus">
         <fieldset>
@@ -39,13 +39,13 @@ $default_role = $capsman->current;
                                 foreach ($roles as $role => $name) :
                                     $name = translate_user_role($name);
                                     ?>
-                                    <option value="<?php echo $role;?>" <?php selected($default_role, $role);?>><?php echo $name;?></option>
+                                    <option value="<?php echo esc_attr($role);?>" <?php selected($default_role, $role);?>><?php echo esc_html($name);?></option>
                                 <?php
                                 endforeach;
                                 ?>
                             </select> &nbsp;
                             <input type="submit" name="admin-menu-submit"
-                                value="<?php _e('Save Changes', 'capsman-enhanced') ?>"
+                                value="<?php esc_html_e('Save Changes', 'capsman-enhanced') ?>"
                                 class="button-primary ppc-admin-menu-submit" style="float:right" />
                         </div>
                         <div id="pp-capability-menu-wrapper" class="postbox" style="box-shadow: none;">
@@ -55,11 +55,11 @@ $default_role = $capsman->current;
                                     <img src="<?php echo plugin_dir_url(CME_FILE) . 'includes-core/pp-capabilities-admin-menus-mobile.jpg';?>" class="pp-capability-mobile" />
                                     <div class="pp-capability-menus-promo-content">
                                         <p>
-                                            <?php _e('You can restrict access to admin menu screens. This feature is available in PublishPress Capabilities Pro', 'capsman-enhanced'); ?>
+                                            <?php esc_html_e('You can restrict access to admin menu screens. This feature is available in PublishPress Capabilities Pro', 'capsman-enhanced'); ?>
                                         </p>
                                         <p>
                                             <a href="https://publishpress.com/links/capabilities-banner" target="_blank">
-                                                <?php _e('Upgrade to Pro', 'capsman-enhanced'); ?>
+                                                <?php esc_html_e('Upgrade to Pro', 'capsman-enhanced'); ?>
                                             </a>
                                         </p>
                                     </div>

--- a/includes-core/editor-features-promo.php
+++ b/includes-core/editor-features-promo.php
@@ -21,7 +21,7 @@
     <tr class="ppc-menu-row parent-menu pp-promo-overlay-row pp-promo-blur">
 
         <td colspan="3">
-            <h4 class="ppc-menu-row-section"><?php _e('Metaboxes', 'capsman-enhanced'); ?></h4>
+            <h4 class="ppc-menu-row-section"><?php esc_html_e('Metaboxes', 'capsman-enhanced'); ?></h4>
         </td>
     </tr>
     <tr class="ppc-menu-row parent-menu pp-promo-overlay-row pp-promo-blur">
@@ -29,7 +29,7 @@
         <td class="menu-column ppc-menu-item">
 
                 <span class="gutenberg menu-item-link">
-                <strong><i class="dashicons dashicons-arrow-right"></i> <?php _e('Checklist', 'capsman-enhanced'); ?> </strong></span>
+                <strong><i class="dashicons dashicons-arrow-right"></i> <?php esc_html_e('Checklist', 'capsman-enhanced'); ?> </strong></span>
         </td>
 
         <td class="restrict-column ppc-menu-checkbox">
@@ -42,7 +42,7 @@
     <tr class="ppc-menu-row parent-menu pp-promo-overlay-row pp-promo-blur">
         <td class="menu-column ppc-menu-item">
                 <span class="gutenberg menu-item-link restricted">
-                <strong><i class="dashicons dashicons-arrow-right"></i> <?php _e('Editorial Comments', 'capsman-enhanced'); ?></strong></span>
+                <strong><i class="dashicons dashicons-arrow-right"></i> <?php esc_html_e('Editorial Comments', 'capsman-enhanced'); ?></strong></span>
         </td>
 
         <td class="restrict-column ppc-menu-checkbox">
@@ -55,7 +55,7 @@
     <tr class="ppc-menu-row parent-menu pp-promo-overlay-row pp-promo-blur">
         <td class="menu-column ppc-menu-item">
                 <span class="gutenberg menu-item-link">
-                <strong><i class="dashicons dashicons-arrow-right"></i> <?php _e('Notifications', 'capsman-enhanced'); ?></strong></span>
+                <strong><i class="dashicons dashicons-arrow-right"></i> <?php esc_html_e('Notifications', 'capsman-enhanced'); ?></strong></span>
         </td>
 
         <td class="restrict-column ppc-menu-checkbox">
@@ -68,7 +68,7 @@
     <tr class="ppc-menu-row parent-menu pp-promo-overlay-row pp-promo-blur">
         <td class="menu-column ppc-menu-item">
                 <span class="gutenberg menu-item-link">
-                <strong><i class="dashicons dashicons-arrow-right"></i> <?php _e('TaxoPress - Settings', 'capsman-enhanced'); ?></strong></span>
+                <strong><i class="dashicons dashicons-arrow-right"></i> <?php esc_html_e('TaxoPress - Settings', 'capsman-enhanced'); ?></strong></span>
         </td>
 
         <td class="restrict-column ppc-menu-checkbox">
@@ -83,12 +83,12 @@
         <td colspan="3">
             <div class="pp-promo-upgrade-notice">
                 <p>
-                    <?php _e('You can hide plugin metaboxes. You can also hide specific items by entering their CSS class or ID. This feature is available in PublishPress Capabilities Pro.',
+                    <?php esc_html_e('You can hide plugin metaboxes. You can also hide specific items by entering their CSS class or ID. This feature is available in PublishPress Capabilities Pro.',
                         'capsman-enhanced'); ?>
                 </p>
                 <p>
                     <a href="https://publishpress.com/links/capabilities-banner" target="_blank">
-                        <?php _e('Upgrade to Pro', 'capsman-enhanced'); ?>
+                        <?php esc_html_e('Upgrade to Pro', 'capsman-enhanced'); ?>
                     </a>
                 </p>
             </div>
@@ -98,14 +98,14 @@
     <tr class="ppc-menu-row parent-menu pp-promo-overlay-row pp-promo-blur">
 
         <td colspan="3">
-            <h4 class="ppc-menu-row-section"><?php _e('Custom Items', 'capsman-enhanced'); ?></h4>
+            <h4 class="ppc-menu-row-section"><?php esc_html_e('Custom Items', 'capsman-enhanced'); ?></h4>
         </td>
     </tr>
     <tr class="ppc-menu-row parent-menu pp-promo-overlay-row pp-promo-blur">
         <td class="menu-column ppc-menu-item">
                 <span class="gutenberg menu-item-link">
-                <strong><i class="dashicons dashicons-arrow-right"></i> <?php _e('Custom item one', 'capsman-enhanced'); ?> <small>(.custom-plugin-item, #custom-plugin-item)</small> &nbsp; <span
-                        class="ppc-custom-features-delete"><small>(<?php _e('Delete', 'capsman-enhanced'); ?>)</small></span></strong></span>
+                <strong><i class="dashicons dashicons-arrow-right"></i> <?php esc_html_e('Custom item one', 'capsman-enhanced'); ?> <small>(.custom-plugin-item, #custom-plugin-item)</small> &nbsp; <span
+                        class="ppc-custom-features-delete"><small>(<?php esc_html_e('Delete', 'capsman-enhanced'); ?>)</small></span></strong></span>
         </td>
 
         <td class="restrict-column ppc-menu-checkbox">
@@ -118,8 +118,8 @@
     <tr class="ppc-menu-row parent-menu pp-promo-overlay-row pp-promo-blur">
         <td class="menu-column ppc-menu-item">
                 <span class="gutenberg menu-item-link restricted">
-                <strong><i class="dashicons dashicons-arrow-right"></i> <?php _e('Permalink: Descriptive Caption', 'capsman-enhanced'); ?> <small>(.editor-post-link p)</small> &nbsp; <span
-                        class="ppc-custom-features-delete"><small>(<?php _e('Delete', 'capsman-enhanced'); ?>)</small></span>                </strong></span>
+                <strong><i class="dashicons dashicons-arrow-right"></i> <?php esc_html_e('Permalink: Descriptive Caption', 'capsman-enhanced'); ?> <small>(.editor-post-link p)</small> &nbsp; <span
+                        class="ppc-custom-features-delete"><small>(<?php esc_html_e('Delete', 'capsman-enhanced'); ?>)</small></span>                </strong></span>
         </td>
 
         <td class="restrict-column ppc-menu-checkbox">
@@ -132,7 +132,7 @@
     <tr class="ppc-menu-row parent-menu pp-promo-overlay-row pp-promo-blur">
         <td class="menu-column ppc-menu-item">
                 <span class="gutenberg menu-item-link">
-                <strong><i class="dashicons dashicons-arrow-right"></i> <?php _e('Page Attributes: Order', 'capsman-enhanced'); ?> <small>(.editor-page-attributes__order)</small> &nbsp; <span class="ppc-custom-features-delete"><small>(<?php _e('Delete', 'capsman-enhanced'); ?>)</small></span>                </strong></span>
+                <strong><i class="dashicons dashicons-arrow-right"></i> <?php esc_html_e('Page Attributes: Order', 'capsman-enhanced'); ?> <small>(.editor-page-attributes__order)</small> &nbsp; <span class="ppc-custom-features-delete"><small>(<?php esc_html_e('Delete', 'capsman-enhanced'); ?>)</small></span>                </strong></span>
         </td>
 
         <td class="restrict-column ppc-menu-checkbox">

--- a/includes-core/nav-menus-promo.php
+++ b/includes-core/nav-menus-promo.php
@@ -26,7 +26,7 @@ $default_role = $capsman->current;
 
 <div class="wrap publishpress-caps-manage pressshack-admin-wrapper pp-capability-menus-wrapper-promo">
     <div id="icon-capsman-admin" class="icon32"></div>
-    <h2><?php _e('Navigation Menu Restrictions', 'capsman-enhanced'); ?></h2>
+    <h2><?php esc_html_e('Navigation Menu Restrictions', 'capsman-enhanced'); ?></h2>
 
     <form method="post" id="ppc-nav-menu-form" action="admin.php?page=pp-capabilities-nav-menus">
         <fieldset>
@@ -41,7 +41,7 @@ $default_role = $capsman->current;
                                     foreach ($roles as $role => $name) {
                                         $name = translate_user_role($name);
                                         ?>
-                                        <option value="<?php echo $role; ?>" <?php selected($default_role, $role); ?>> <?php echo $name; ?>
+                                        <option value="<?php echo esc_attr($role); ?>" <?php selected($default_role, $role); ?>> <?php echo esc_html($name); ?>
                                             &nbsp;
                                         </option>
                                     <?php } ?>
@@ -49,7 +49,7 @@ $default_role = $capsman->current;
 
                             </select> &nbsp;
                             <input type="submit" name="nav-menu-submit"
-                                   value="<?php _e('Save Changes', 'capsman-enhanced') ?>"
+                                   value="<?php esc_html_e('Save Changes', 'capsman-enhanced') ?>"
                                    class="button-primary ppc-nav-menu-submit" style="float:right" />
                         </div>
 
@@ -60,11 +60,11 @@ $default_role = $capsman->current;
                                     <img src="<?php echo plugin_dir_url(CME_FILE) . 'includes-core/pp-capabilities-nav-menus-mobile.jpg';?>" class="pp-capability-mobile" />
                                     <div class="pp-capability-menus-promo-content">
                                         <p>
-                                            <?php _e('You can restrict access to navigation menus. This feature is available in PublishPress Capabilities Pro', 'capsman-enhanced'); ?>
+                                            <?php esc_html_e('You can restrict access to navigation menus. This feature is available in PublishPress Capabilities Pro', 'capsman-enhanced'); ?>
                                         </p>
                                         <p>
                                             <a href="https://publishpress.com/links/capabilities-banner" target="_blank">
-                                                <?php _e('Upgrade to Pro', 'capsman-enhanced'); ?>
+                                                <?php esc_html_e('Upgrade to Pro', 'capsman-enhanced'); ?>
                                             </a>
                                         </p>
                                     </div>

--- a/includes/admin.php
+++ b/includes/admin.php
@@ -125,10 +125,26 @@ if( defined('PRESSPERMIT_ACTIVE') ) {
 			<?php
 			$msg = __( '<strong>Note:</strong> Capability changes <strong>remain in the database</strong> after plugin deactivation.', 'capsman-enhanced' );
 
+			// preserve translation strings for now
+			$_msg = str_replace('<strong>', '%%b', $msg);
+			$_msg = str_replace('</strong>', '%%ub', $_msg);
+			$_msg = esc_html($_msg);
+			$_msg = str_replace('%%b', '<strong>', $_msg);
+			$msg = str_replace('%%ub', '</strong>', $_msg);
+
 			if (defined('PRESSPERMIT_ACTIVE') && function_exists('presspermit')) {
 				if ($group = presspermit()->groups()->getMetagroup('wp_role', $this->current)) {
+					$msg = __('<strong>Note:</strong> Capability changes <strong>remain in the database</strong> after plugin deactivation. You can also configure this role as a %sPermission Group%s.', 'capsman-enhanced');
+
+					// preserve translation strings for now
+					$_msg = str_replace('<strong>', '%%b', $msg);
+					$_msg = str_replace('</strong>', '%%ub', $_msg);
+					$_msg = esc_html($_msg);
+					$_msg = str_replace('%%b', '<strong>', $_msg);
+					$msg = str_replace('%%ub', '</strong>', $_msg);
+
 					$msg = sprintf(
-						__('<strong>Note:</strong> Capability changes <strong>remain in the database</strong> after plugin deactivation. You can also configure this role as a %sPermission Group%s.', 'capsman-enhanced'),
+						$msg,
 						'<a href="' . admin_url("admin.php?page=presspermit-edit-permissions&action=edit&agent_id={$group->ID}") . '">',
 						'</a>'
 					);

--- a/includes/admin.php
+++ b/includes/admin.php
@@ -65,7 +65,7 @@ if( defined('PRESSPERMIT_ACTIVE') ) {
 	<div id="icon-capsman-admin" class="icon32"></div>
 	<?php /* endif; */ ?>
 
-	<h1 <?php echo $style;?>><?php _e('Role Capabilities', 'capsman-enhanced') ?></h1>
+	<h1 <?php echo $style;?>><?php esc_html_e('Role Capabilities', 'capsman-enhanced') ?></h1>
 
 	<?php
 	echo pp_capabilities_roles()->notify->display();
@@ -96,9 +96,11 @@ if( defined('PRESSPERMIT_ACTIVE') ) {
 		<select name="role">
 			<?php
 			foreach ( $roles as $role => $name ) {
+				$role = sanitize_key($role);
+
 				if (pp_capabilities_is_editable_role($role)) {
 					$name = translate_user_role($name);
-					echo '<option value="' . $role .'"'; selected($default, $role); echo '> ' . $name . ' &nbsp;</option>';
+					echo '<option value="' . $role .'"'; selected($default, $role); echo '> ' . esc_html($name) . ' &nbsp;</option>';
 				}
 			}
 			?>
@@ -111,7 +113,7 @@ if( defined('PRESSPERMIT_ACTIVE') ) {
 		<td class="content">
 
 			<div style="float:right">
-			<input type="submit" name="SaveRole" value="<?php echo (in_array(get_locale(), ['en_EN', 'en_US'])) ? 'Save Capabilities' : _e('Save Changes', 'capsman-enhanced'); ?>" class="button-primary" />
+			<input type="submit" name="SaveRole" value="<?php echo (in_array(get_locale(), ['en_EN', 'en_US'])) ? 'Save Capabilities' : esc_html_e('Save Changes', 'capsman-enhanced'); ?>" class="button-primary" />
 			</div>
 
 			<?php
@@ -218,23 +220,23 @@ if( defined('PRESSPERMIT_ACTIVE') ) {
 			$stati = get_post_stati( array( 'internal' => false ) );
 
 			$cap_type_names = array(
-				'' => __( '&nbsp;', 'capsman-enhanced' ),
-				'read' => __( 'Reading', 'capsman-enhanced' ),
-				'edit' => __( 'Editing', 'capsman-enhanced' ),
-				'delete' => __( 'Deletion', 'capsman-enhanced' )
+				'' => esc_html__( '&nbsp;', 'capsman-enhanced' ),
+				'read' => esc_html__( 'Reading', 'capsman-enhanced' ),
+				'edit' => esc_html__( 'Editing', 'capsman-enhanced' ),
+				'delete' => esc_html__( 'Deletion', 'capsman-enhanced' )
 			);
 
 			$cap_tips = array(
-				'read_private' => __( 'can read posts which are currently published with private visibility', 'capsman-enhanced' ),
-				'edit' => __( 'has basic editing capability (but may need other capabilities based on post status and ownership)', 'capsman-enhanced' ),
-				'edit_others' => __( 'can edit posts which were created by other users', 'capsman-enhanced' ),
-				'edit_published' => __( 'can edit posts which are currently published', 'capsman-enhanced' ),
-				'edit_private' => __( 'can edit posts which are currently published with private visibility', 'capsman-enhanced' ),
-				'publish' => __( 'can make a post publicly visible', 'capsman-enhanced' ),
-				'delete' => __( 'has basic deletion capability (but may need other capabilities based on post status and ownership)', 'capsman-enhanced' ),
-				'delete_others' => __( 'can delete posts which were created by other users', 'capsman-enhanced' ),
-				'delete_published' => __( 'can delete posts which are currently published', 'capsman-enhanced' ),
-				'delete_private' => __( 'can delete posts which are currently published with private visibility', 'capsman-enhanced' ),
+				'read_private' => esc_attr__( 'can read posts which are currently published with private visibility', 'capsman-enhanced' ),
+				'edit' => esc_attr__( 'has basic editing capability (but may need other capabilities based on post status and ownership)', 'capsman-enhanced' ),
+				'edit_others' => esc_attr__( 'can edit posts which were created by other users', 'capsman-enhanced' ),
+				'edit_published' => esc_attr__( 'can edit posts which are currently published', 'capsman-enhanced' ),
+				'edit_private' => esc_attr__( 'can edit posts which are currently published with private visibility', 'capsman-enhanced' ),
+				'publish' => esc_attr__( 'can make a post publicly visible', 'capsman-enhanced' ),
+				'delete' => esc_attr__( 'has basic deletion capability (but may need other capabilities based on post status and ownership)', 'capsman-enhanced' ),
+				'delete_others' => esc_attr__( 'can delete posts which were created by other users', 'capsman-enhanced' ),
+				'delete_published' => esc_attr__( 'can delete posts which are currently published', 'capsman-enhanced' ),
+				'delete_private' => esc_attr__( 'can delete posts which are currently published with private visibility', 'capsman-enhanced' ),
 			);
 
 			$default_caps = array( 'read_private_posts', 'edit_posts', 'edit_others_posts', 'edit_published_posts', 'edit_private_posts', 'publish_posts', 'delete_posts', 'delete_others_posts', 'delete_published_posts', 'delete_private_posts',
@@ -295,11 +297,13 @@ if( defined('PRESSPERMIT_ACTIVE') ) {
 
 						if ($extra_tabs = apply_filters('pp_capabilities_extra_post_capability_tabs', [])) {
 							foreach($extra_tabs as $tab_slug => $tab_caption) {
+								$tab_slug = sanitize_key($tab_slug);
+								
 								$tab_id = "cme-cap-type-tables-{$tab_slug}";
 								$tab_active = ($tab_id == $active_tab_id) ? $ppc_tab_active : '';
 
 								echo '<li data-slug="' . $tab_slug . '"' . ' data-content="' . $tab_id . '"' . $tab_active . '>'
-								. $tab_caption .
+								. esc_html($tab_caption) .
 								'</li>';
 							}
 						}
@@ -307,7 +311,7 @@ if( defined('PRESSPERMIT_ACTIVE') ) {
 						// caps: other
 						$tab_id = "cme-cap-type-tables-other";
 						$tab_active = ($tab_id == $active_tab_id) ? $ppc_tab_active : '';
-						$tab_caption = __( 'WordPress Core', 'capsman-enhanced' );
+						$tab_caption = esc_html__( 'WordPress Core', 'capsman-enhanced' );
 
 						echo '<li data-slug="other" data-content="' . $tab_id . '"' . $tab_active . '>' . $tab_caption . '</li>';
 
@@ -468,7 +472,9 @@ if( defined('PRESSPERMIT_ACTIVE') ) {
 						}
 						$plugin_caps = apply_filters('cme_plugin_capabilities', $plugin_caps);
 						foreach($plugin_caps as $plugin => $__plugin_caps) {
-							$_plugin_caps = array_fill_keys($__plugin_caps, true);
+							$plugin = esc_html($plugin);
+
+							$_plugin_caps = array_fill_keys(array_map('sanitize_key', $__plugin_caps), true);
 
 							$tab_slug = str_replace(' ', '-', strtolower($plugin));
 							$tab_id = 'cme-cap-type-tables-' . $tab_slug;
@@ -481,12 +487,12 @@ if( defined('PRESSPERMIT_ACTIVE') ) {
 
 						$tab_id = "cme-cap-type-tables-invalid";
 						$tab_active = ($tab_id == $active_tab_id) ? $ppc_tab_active : '';
-						$tab_caption = __( 'Invalid Capabilities', 'capsman-enhanced' );
+						$tab_caption = esc_html__( 'Invalid Capabilities', 'capsman-enhanced' );
 						echo '<li id="cme_tab_invalid_caps" data-slug="invalid" data-content="cme-cap-type-tables-' . $tab_id . '"' . $tab_active . ' style="display:none;">' . $tab_caption . '</li>';
 
 						$tab_id = "cme-cap-type-tables-additional";
 						$tab_active = ($tab_id == $active_tab_id) ? $ppc_tab_active : '';
-						$tab_caption = __( 'Additional', 'capsman-enhanced' );
+						$tab_caption = esc_html__( 'Additional', 'capsman-enhanced' );
 						echo '<li data-slug="additional" data-content="' . $tab_id . '"' . $tab_active . '>' . $tab_caption . '</li>';
 						?>
 					</ul>
@@ -530,16 +536,16 @@ if( defined('PRESSPERMIT_ACTIVE') ) {
 
 							echo "<div id='$id' style='display:$div_display;'>";
 
-							$caption_pattern = ('taxonomy' == $item_type) ? __('Term %s Capabilities', 'capability-manager-enhanced') : __('Post %s Capabilities', 'capability-manager-enhanced');
+							$caption_pattern = ('taxonomy' == $item_type) ? esc_html__('Term %s Capabilities', 'capability-manager-enhanced') : esc_html__('Post %s Capabilities', 'capability-manager-enhanced');
 
 							echo '<h3>' .  sprintf($caption_pattern, $cap_type_names[$cap_type]) . '</h3>';
 
 							echo '<div class="ppc-filter-wrapper">';
 								echo '<select class="ppc-filter-select">';
-									$filter_caption = ('taxonomy' == $item_type) ? __('Filter by taxonomy', 'capability-manager-enhanced') : __('Filter by post type', 'capability-manager-enhanced');
+									$filter_caption = ('taxonomy' == $item_type) ? esc_html__('Filter by taxonomy', 'capability-manager-enhanced') : esc_html__('Filter by post type', 'capability-manager-enhanced');
 									echo '<option value="">' . $filter_caption . '</option>';
 								echo '</select>';
-								echo ' <button class="button secondary-button ppc-filter-select-reset" type="button">' . __('Clear', 'capability-manager-enhanced') . '</button>';
+								echo ' <button class="button secondary-button ppc-filter-select-reset" type="button">' . esc_html__('Clear', 'capability-manager-enhanced') . '</button>';
 							echo '</div>';
 
 							echo "<table class='widefat fixed striped cme-typecaps cme-typecaps-$cap_type'>";
@@ -632,7 +638,7 @@ if( defined('PRESSPERMIT_ACTIVE') ) {
 
 												if ( $is_administrator || current_user_can($cap_name) ) {
 													if ( ! empty($pp_metagroup_caps[$cap_name]) ) {
-														$title = ' title="' . sprintf( __( '%s: assigned by Permission Group', 'capsman-enhanced' ), $cap_name ) . '"';
+														$title = ' title="' . sprintf( esc_attr__( '%s: assigned by Permission Group', 'capsman-enhanced' ), $cap_name ) . '"';
 													} else {
 														$title = ' title="' . $cap_name . '"';
 													}
@@ -648,7 +654,7 @@ if( defined('PRESSPERMIT_ACTIVE') ) {
 												}
 											} else {
 												//$td_classes []= "cap-unreg";
-												$title = 'title="' . sprintf( __( 'shared capability: %s', 'capsman-enhanced' ), esc_attr( $type_obj->cap->$prop ) ) . '"';
+												$title = 'title="' . sprintf( esc_attr__( 'shared capability: %s', 'capsman-enhanced' ), esc_attr( $type_obj->cap->$prop ) ) . '"';
 											}
 
 											if ( isset($rcaps[$cap_name]) && empty($rcaps[$cap_name]) ) {
@@ -726,13 +732,13 @@ if( defined('PRESSPERMIT_ACTIVE') ) {
 					<div id="<?php echo $id;?>" style="display:<?php echo $div_display;?>">
 						<?php
 
-						echo '<h3>' . __( 'WordPress Core Capabilities', 'capsman-enhanced' ) . '</h3>';
+						echo '<h3>' . esc_html__( 'WordPress Core Capabilities', 'capsman-enhanced' ) . '</h3>';
 
 						echo '<div class="ppc-filter-wrapper">';
-							echo '<input type="text" class="regular-text ppc-filter-text" placeholder="' . __('Filter by capability', 'capability-manager-enhanced') . '">';
-							echo ' <button class="button secondary-button ppc-filter-text-reset" type="button">' . __('Clear', 'capability-manager-enhanced') . '</button>';
+							echo '<input type="text" class="regular-text ppc-filter-text" placeholder="' . esc_html__('Filter by capability', 'capability-manager-enhanced') . '">';
+							echo ' <button class="button secondary-button ppc-filter-text-reset" type="button">' . esc_html__('Clear', 'capability-manager-enhanced') . '</button>';
 						echo '</div>';
-						echo '<div class="ppc-filter-no-results" style="display:none;">' . __( 'No results found. Please try again with a different word.', 'capsman-enhanced' ) . '</div>';
+						echo '<div class="ppc-filter-no-results" style="display:none;">' . esc_html__( 'No results found. Please try again with a different word.', 'capsman-enhanced' ) . '</div>';
 
 						echo '<table class="widefat fixed striped form-table cme-checklist">';
 
@@ -742,17 +748,19 @@ if( defined('PRESSPERMIT_ACTIVE') ) {
 
 						$core_caps = _cme_core_caps();
 						foreach( array_keys($core_caps) as $cap_name ) {
+							$cap_name = sanitize_key($cap_name);
+
 							if ( ! $is_administrator && ! current_user_can($cap_name) )
 								continue;
 
 							// Output first <tr>
 							if ( $centinel_ == true ) {
-								echo '<tr class="' . esc_html($cap_name) . '">';
+								echo '<tr class="' . $cap_name . '">';
 								$centinel_ = false;
 							}
 
 							if ( $i == $checks_per_row ) {
-								echo '</tr><tr class="' . esc_html($cap_name) . '">';
+								echo '</tr><tr class="' . $cap_name . '">';
 								$i = 0;
 							}
 
@@ -782,7 +790,7 @@ if( defined('PRESSPERMIT_ACTIVE') ) {
 											$class .= ' cap-locked';
 											$disabled = 'disabled="disabled"';
 											if ( 'administrator' != $this->current ) {
-												$title = esc_attr( __('Lockout Prevention: To remove read capability, first remove WordPress admin / editing capabilities, or add "dashboard_lockout_ok" capability', 'capsman-enhanced' ) );
+												$title = __('Lockout Prevention: To remove read capability, first remove WordPress admin / editing capabilities, or add "dashboard_lockout_ok" capability', 'capsman-enhanced' );
 											}
 										}
 									}
@@ -790,7 +798,7 @@ if( defined('PRESSPERMIT_ACTIVE') ) {
 							}
 
 							?>
-							<td class="<?php echo $class; ?>"><span class="cap-x">X</span><label title="<?php echo $title;?>"><input type="checkbox" name="caps[<?php echo $cap_name; ?>]" autocomplete="off" value="1" <?php echo $checked . $disabled;?> />
+							<td class="<?php echo $class; ?>"><span class="cap-x">X</span><label title="<?php echo esc_attr($title);?>"><input type="checkbox" name="caps[<?php echo $cap_name; ?>]" autocomplete="off" value="1" <?php echo $checked . $disabled;?> />
 							<span>
 							<?php
 							echo str_replace( '_', ' ', $cap_name );
@@ -825,7 +833,7 @@ if( defined('PRESSPERMIT_ACTIVE') ) {
 						<tr class="cme-bulk-select">
 						<td colspan="<?php echo $checks_per_row;?>">
 						<span style="float:right">
-						<input type="checkbox" class="cme-check-all" autocomplete="off" title="<?php _e('check/uncheck all', 'capsman-enhanced');?>">&nbsp;&nbsp;<a class="cme-neg-all" href="#" title="<?php _e('negate all (storing as disabled capabilities)', 'capsman-enhanced');?>">X</a> <a class="cme-switch-all" href="#" title="<?php _e('negate none (add/remove all capabilities normally)', 'capsman-enhanced');?>">X</a>
+						<input type="checkbox" class="cme-check-all" autocomplete="off" title="<?php esc_attr_e('check/uncheck all', 'capsman-enhanced');?>">&nbsp;&nbsp;<a class="cme-neg-all" href="#" title="<?php esc_attr_e('negate all (storing as disabled capabilities)', 'capsman-enhanced');?>">X</a> <a class="cme-switch-all" href="#" title="<?php esc_attr_e('negate none (add/remove all capabilities normally)', 'capsman-enhanced');?>">X</a>
 						</span>
 						</td></tr>
 
@@ -849,6 +857,8 @@ if( defined('PRESSPERMIT_ACTIVE') ) {
 					$plugin_caps = apply_filters('cme_plugin_capabilities', $plugin_caps);
 
 					foreach($plugin_caps as $plugin => $__plugin_caps) {
+						$plugin = esc_html($plugin);
+
 						$_plugin_caps = array_fill_keys($__plugin_caps, true);
 
 						$id = 'cme-cap-type-tables-' . str_replace( ' ', '-', strtolower($plugin));
@@ -856,13 +866,13 @@ if( defined('PRESSPERMIT_ACTIVE') ) {
 
 						echo '<div id="' . $id . '" style="display:' . $div_display . '">';
 
-						echo '<h3 class="cme-cap-section">' . sprintf(__( 'Plugin Capabilities &ndash; %s', 'capsman-enhanced' ), str_replace('_', ' ', $plugin )) . '</h3>';
+						echo '<h3 class="cme-cap-section">' . sprintf(esc_html__( 'Plugin Capabilities &ndash; %s', 'capsman-enhanced' ), str_replace('_', ' ', $plugin )) . '</h3>';
 
 						echo '<div class="ppc-filter-wrapper">';
-							echo '<input type="text" class="regular-text ppc-filter-text" placeholder="' . __('Filter by capability', 'capability-manager-enhanced') . '">';
-							echo ' <button class="button secondary-button ppc-filter-text-reset" type="button">' . __('Clear', 'capability-manager-enhanced') . '</button>';
+							echo '<input type="text" class="regular-text ppc-filter-text" placeholder="' . esc_html__('Filter by capability', 'capability-manager-enhanced') . '">';
+							echo ' <button class="button secondary-button ppc-filter-text-reset" type="button">' . esc_html__('Clear', 'capability-manager-enhanced') . '</button>';
 						echo '</div>';
-						echo '<div class="ppc-filter-no-results" style="display:none;">' . __( 'No results found. Please try again with a different word.', 'capsman-enhanced' ) . '</div>';
+						echo '<div class="ppc-filter-no-results" style="display:none;">' . esc_html__( 'No results found. Please try again with a different word.', 'capsman-enhanced' ) . '</div>';
 
 						echo '<table class="widefat fixed striped form-table cme-checklist">';
 
@@ -871,6 +881,8 @@ if( defined('PRESSPERMIT_ACTIVE') ) {
 						$i = 0; $first_row = true;
 
 						foreach( array_keys($_plugin_caps) as $cap_name ) {
+							$cap_name = sanitize_key($cap_name);
+
 							if ( isset( $type_caps[$cap_name] ) || isset($core_caps[$cap_name]) || isset($type_metacaps[$cap_name]) ) {
 								continue;
 							}
@@ -880,12 +892,12 @@ if( defined('PRESSPERMIT_ACTIVE') ) {
 
 							// Output first <tr>
 							if ( $centinel_ == true ) {
-								echo '<tr class="' . esc_html($cap_name) . '">';
+								echo '<tr class="' . $cap_name . '">';
 								$centinel_ = false;
 							}
 
 							if ( $i == $checks_per_row ) {
-								echo '</tr><tr class="' . esc_html($cap_name) . '">';
+								echo '</tr><tr class="' . $cap_name . '">';
 								$i = 0;
 							}
 
@@ -905,7 +917,7 @@ if( defined('PRESSPERMIT_ACTIVE') ) {
 							$checked = checked(1, ! empty($rcaps[$cap_name]), false );
 							$title = $title_text;
 							?>
-							<td class="<?php echo $class; ?>"><span class="cap-x">X</span><label title="<?php echo $title;?>"><input type="checkbox" name="caps[<?php echo $cap_name; ?>]" autocomplete="off" value="1" <?php echo $checked . $disabled;?> />
+							<td class="<?php echo $class; ?>"><span class="cap-x">X</span><label title="<?php echo esc_attr($title);?>"><input type="checkbox" name="caps[<?php echo $cap_name; ?>]" autocomplete="off" value="1" <?php echo $checked . $disabled;?> />
 							<span>
 							<?php
 							echo str_replace( '_', ' ', $cap_name );
@@ -935,7 +947,7 @@ if( defined('PRESSPERMIT_ACTIVE') ) {
 						<tr class="cme-bulk-select">
 						<td colspan="<?php echo $checks_per_row;?>">
 						<span style="float:right">
-						<input type="checkbox" class="cme-check-all" title="<?php _e('check/uncheck all', 'capsman-enhanced');?>">&nbsp;&nbsp;<a class="cme-neg-all" href="#" autocomplete="off" title="<?php _e('negate all (storing as disabled capabilities)', 'capsman-enhanced');?>">X</a> <a class="cme-switch-all" href="#" title="<?php _e('negate none (add/remove all capabilities normally)', 'capsman-enhanced');?>">X</a>
+						<input type="checkbox" class="cme-check-all" title="<?php esc_attr_e('check/uncheck all', 'capsman-enhanced');?>">&nbsp;&nbsp;<a class="cme-neg-all" href="#" autocomplete="off" title="<?php esc_attr_e('negate all (storing as disabled capabilities)', 'capsman-enhanced');?>">X</a> <a class="cme-switch-all" href="#" title="<?php esc_attr_e('negate none (add/remove all capabilities normally)', 'capsman-enhanced');?>">X</a>
 						</span>
 						</td></tr>
 
@@ -950,7 +962,7 @@ if( defined('PRESSPERMIT_ACTIVE') ) {
 						$div_display = ($id == $active_tab_id) ? 'block' : 'none';
 
 						echo '<div id="' . $id . '" style="display:' . $div_display . '">';
-						echo '<h3 class="cme-cap-section">' . __( 'Invalid Capabilities', 'capsman-enhanced' ) . '</h3>';
+						echo '<h3 class="cme-cap-section">' . esc_html__( 'Invalid Capabilities', 'capsman-enhanced' ) . '</h3>';
 						?>
 
 						<script type="text/javascript">
@@ -963,7 +975,7 @@ if( defined('PRESSPERMIT_ACTIVE') ) {
 
 						<div>
 						<span class="cme-subtext">
-							<?php _e('The following entries have no effect. Please assign desired capabilities in the Read / Edit / Delete grid above.', 'capsman-enhanced');?>
+							<?php esc_html_e('The following entries have no effect. Please assign desired capabilities in the Read / Edit / Delete grid above.', 'capsman-enhanced');?>
 						</span>
 						</div>
 
@@ -980,6 +992,8 @@ if( defined('PRESSPERMIT_ACTIVE') ) {
 						uasort( $this->capabilities, 'strnatcasecmp' );  // sort by array values, but maintain keys );
 
 						foreach ( $this->capabilities as $cap_name => $cap ) :
+							$cap_name = sanitize_key($cap_name);
+
 							if (!isset($type_metacaps[$cap_name]) || empty($rcaps[$cap_name])) {
 								continue;
 							}
@@ -1006,7 +1020,7 @@ if( defined('PRESSPERMIT_ACTIVE') ) {
 							<td class="<?php echo $class; ?>"><span class="cap-x">X</span><label title="<?php echo $title_text;?>"><input type="checkbox" name="caps[<?php echo $cap_name; ?>]" autocomplete="off" value="1" <?php echo $checked . $disabled;?> />
 							<span>
 							<?php
-							echo str_replace( '_', ' ', $cap );
+							echo esc_html(str_replace( '_', ' ', $cap ));
 							?>
 							</span></label><a href="#" class="neg-cap">&nbsp;x&nbsp;</a>
 							<?php if ( false !== strpos( $class, 'cap-neg' ) ) :?>
@@ -1046,13 +1060,13 @@ if( defined('PRESSPERMIT_ACTIVE') ) {
 					<div id="<?php echo $id;?>" style="display:<?php echo $div_display;?>">
 						<?php
 						// caps: additional
-						echo '<h3 class="cme-cap-section">' . __( 'Additional Capabilities', 'capsman-enhanced' ) . '</h3>';
+						echo '<h3 class="cme-cap-section">' . esc_html__( 'Additional Capabilities', 'capsman-enhanced' ) . '</h3>';
 
 						echo '<div class="ppc-filter-wrapper">';
-							echo '<input type="text" class="regular-text ppc-filter-text" placeholder="' . __('Filter by capability', 'capability-manager-enhanced') . '">';
-							echo ' <button class="button secondary-button ppc-filter-text-reset" type="button">' . __('Clear', 'capability-manager-enhanced') . '</button>';
+							echo '<input type="text" class="regular-text ppc-filter-text" placeholder="' . esc_html__('Filter by capability', 'capability-manager-enhanced') . '">';
+							echo ' <button class="button secondary-button ppc-filter-text-reset" type="button">' . esc_html__('Clear', 'capability-manager-enhanced') . '</button>';
 						echo '</div>';
-						echo '<div class="ppc-filter-no-results" style="display:none;">' . __( 'No results found. Please try again with a different word.', 'capsman-enhanced' ) . '</div>';
+						echo '<div class="ppc-filter-no-results" style="display:none;">' . esc_html__( 'No results found. Please try again with a different word.', 'capsman-enhanced' ) . '</div>';
 						?>
 						<table class="widefat fixed striped form-table cme-checklist">
 						<?php
@@ -1069,6 +1083,8 @@ if( defined('PRESSPERMIT_ACTIVE') ) {
 						$additional_caps = apply_filters('publishpress_caps_manage_additional_caps', $this->capabilities);
 
 						foreach ($additional_caps as $cap_name => $cap) :
+							$cap_name = sanitize_key($cap_name);
+							
 
 							if ((isset($type_caps[$cap_name]) && !isset($type_metacaps[$cap_name]))
 							|| isset($core_caps[$cap_name])
@@ -1095,12 +1111,12 @@ if( defined('PRESSPERMIT_ACTIVE') ) {
 
 							// Output first <tr>
 							if ( $centinel_ == true ) {
-								echo '<tr class="' . esc_html($cap_name) . '">';
+								echo '<tr class="' . $cap_name . '">';
 								$centinel_ = false;
 							}
 
 							if ( $i == $checks_per_row ) {
-								echo '</tr><tr class="' . esc_html($cap_name) . '">';
+								echo '</tr><tr class="' . $cap_name . '">';
 								$i = 0; $first_row = false;
 							}
 
@@ -1111,7 +1127,7 @@ if( defined('PRESSPERMIT_ACTIVE') ) {
 
 							if ( ! empty($pp_metagroup_caps[$cap_name]) ) {
 								$class .= ' cap-metagroup';
-								$title_text = sprintf( __( '%s: assigned by Permission Group', 'capsman-enhanced' ), $cap_name );
+								$title_text = sprintf( esc_html__( '%s: assigned by Permission Group', 'capsman-enhanced' ), $cap_name );
 							} else {
 								$title_text = $cap_name;
 							}
@@ -1132,7 +1148,7 @@ if( defined('PRESSPERMIT_ACTIVE') ) {
 							<td class="<?php echo $class; ?>"><span class="cap-x">X</span><label title="<?php echo $title_text;?>"><input type="checkbox" name="caps[<?php echo $cap_name; ?>]" autocomplete="off" value="1" <?php echo $checked . $disabled;?> />
 							<span>
 							<?php
-							echo str_replace( '_', ' ', $cap );
+							echo esc_html(str_replace( '_', ' ', $cap ));
 							?>
 							</span></label><a href="#" class="neg-cap">&nbsp;x&nbsp;</a>
 							<?php if ( false !== strpos( $class, 'cap-neg' ) ) :?>
@@ -1164,7 +1180,7 @@ if( defined('PRESSPERMIT_ACTIVE') ) {
 						<tr class="cme-bulk-select">
 						<td colspan="<?php echo $checks_per_row;?>">
 						<span style="float:right">
-						<input type="checkbox" class="cme-check-all" title="<?php _e('check/uncheck all', 'capsman-enhanced');?>">&nbsp;&nbsp;<a class="cme-neg-all" href="#" autocomplete="off" title="<?php _e('negate all (storing as disabled capabilities)', 'capsman-enhanced');?>">X</a> <a class="cme-switch-all" href="#" title="<?php _e('negate none (add/remove all capabilities normally)', 'capsman-enhanced');?>">X</a>
+						<input type="checkbox" class="cme-check-all" title="<?php esc_attr_e('check/uncheck all', 'capsman-enhanced');?>">&nbsp;&nbsp;<a class="cme-neg-all" href="#" autocomplete="off" title="<?php esc_attr_e('negate all (storing as disabled capabilities)', 'capsman-enhanced');?>">X</a> <a class="cme-switch-all" href="#" title="<?php esc_attr_e('negate none (add/remove all capabilities normally)', 'capsman-enhanced');?>">X</a>
 						</span>
 						</td></tr>
 
@@ -1191,66 +1207,66 @@ if( defined('PRESSPERMIT_ACTIVE') ) {
 
 			<?php /* play.png icon by Pavel: http://kde-look.org/usermanager/search.php?username=InFeRnODeMoN */ ?>
 
-			<div id="pp_features" style="display:none"><div class="pp-logo"><a href="https://publishpress.com/presspermit/"><img src="<?php echo $img_url;?>pp-logo.png" alt="<?php _e('PublishPress Permissions', 'capsman-enhanced');?>" /></a></div><div class="features-wrap"><ul class="pp-features">
+			<div id="pp_features" style="display:none"><div class="pp-logo"><a href="https://publishpress.com/presspermit/"><img src="<?php echo $img_url;?>pp-logo.png" alt="<?php esc_attr_e('PublishPress Permissions', 'capsman-enhanced');?>" /></a></div><div class="features-wrap"><ul class="pp-features">
 			<li>
-			<?php _e( "Automatically define type-specific capabilities for your custom post types and taxonomies", 'capsman-enhanced' );?>
+			<?php esc_html_e( "Automatically define type-specific capabilities for your custom post types and taxonomies", 'capsman-enhanced' );?>
 			<a href="https://presspermit.com/tutorial/regulate-post-type-access" target="_blank"><img class="cme-play" alt="*" src="<?php echo $img_url;?>play.png" /></a></li>
 
 			<li>
-			<?php _e( "Assign standard WP roles supplementally for a specific post type", 'capsman-enhanced' );?>
+			<?php esc_html_e( "Assign standard WP roles supplementally for a specific post type", 'capsman-enhanced' );?>
 			<a href="https://presspermit.com/tutorial/regulate-post-type-access" target="_blank"><img class="cme-play" alt="*" src="<?php echo $img_url;?>play.png" /></a></li>
 
 			<li>
-			<?php _e( "Assign custom WP roles supplementally for a specific post type <em>(Pro)</em>", 'capsman-enhanced' );?>
+			<?php esc_html_e( "Assign custom WP roles supplementally for a specific post type <em>(Pro)</em>", 'capsman-enhanced' );?>
 			</li>
 
 			<li>
-			<?php _e( "Customize reading permissions per-category or per-post", 'capsman-enhanced' );?>
+			<?php esc_html_e( "Customize reading permissions per-category or per-post", 'capsman-enhanced' );?>
 			<a href="https://presspermit.com/tutorial/category-exceptions" target="_blank"><img class="cme-play" alt="*" src="<?php echo $img_url;?>play.png" /></a></li>
 
 			<li>
-			<?php _e( "Customize editing permissions per-category or per-post <em>(Pro)</em>", 'capsman-enhanced' );?>
+			<?php esc_html_e( "Customize editing permissions per-category or per-post <em>(Pro)</em>", 'capsman-enhanced' );?>
 			<a href="https://presspermit.com/tutorial/page-editing-exceptions" target="_blank"><img class="cme-play" alt="*" src="<?php echo $img_url;?>play.png" /></a></li>
 
 			<li>
-			<?php _e( "Custom Post Visibility statuses, fully implemented throughout wp-admin <em>(Pro)</em>", 'capsman-enhanced' );?>
+			<?php esc_html_e( "Custom Post Visibility statuses, fully implemented throughout wp-admin <em>(Pro)</em>", 'capsman-enhanced' );?>
 			<a href="https://presspermit.com/tutorial/custom-post-visibility" target="_blank"><img class="cme-play" alt="*" src="<?php echo $img_url;?>play.png" /></a></li>
 
 			<li>
-			<?php _e( "Custom Moderation statuses for access-controlled, multi-step publishing workflow <em>(Pro)</em>", 'capsman-enhanced' );?>
+			<?php esc_html_e( "Custom Moderation statuses for access-controlled, multi-step publishing workflow <em>(Pro)</em>", 'capsman-enhanced' );?>
 			<a href="https://presspermit.com/tutorial/multi-step-moderation" target="_blank"><img class="cme-play" alt="*" src="<?php echo $img_url;?>play.png" /></a></li>
 
 			<li>
-			<?php _e( "Regulate permissions for Edit Flow post statuses <em>(Pro)</em>", 'capsman-enhanced' );?>
+			<?php esc_html_e( "Regulate permissions for Edit Flow post statuses <em>(Pro)</em>", 'capsman-enhanced' );?>
 			<a href="https://presspermit.com/tutorial/edit-flow-integration" target="_blank"><img class="cme-play" alt="*" src="<?php echo $img_url;?>play.png" /></a></li>
 
 			<li>
-			<?php _e( "Customize the moderated editing of published content with Revisionary or Post Forking <em>(Pro)</em>", 'capsman-enhanced' );?>
+			<?php esc_html_e( "Customize the moderated editing of published content with Revisionary or Post Forking <em>(Pro)</em>", 'capsman-enhanced' );?>
 			<a href="https://presspermit.com/tutorial/published-content-revision" target="_blank"><img class="cme-play" alt="*" src="<?php echo $img_url;?>play.png" /></a></li>
 
 			<li>
-			<?php _e( "Grant Spectator, Participant or Moderator access to specific bbPress forums <em>(Pro)</em>", 'capsman-enhanced' );?>
+			<?php esc_html_e( "Grant Spectator, Participant or Moderator access to specific bbPress forums <em>(Pro)</em>", 'capsman-enhanced' );?>
 			</li>
 
 			<li>
-			<?php _e( "Grant supplemental content permissions to a BuddyPress group <em>(Pro)</em>", 'capsman-enhanced' );?>
+			<?php esc_html_e( "Grant supplemental content permissions to a BuddyPress group <em>(Pro)</em>", 'capsman-enhanced' );?>
 			<a href="https://presspermit.com/tutorial/buddypress-content-permissions" target="_blank"><img class="cme-play" alt="*" src="<?php echo $img_url;?>play.png" /></a></li>
 
 			<li>
-			<?php _e( "WPML integration to mirror permissions to translations <em>(Pro)</em>", 'capsman-enhanced' );?>
+			<?php esc_html_e( "WPML integration to mirror permissions to translations <em>(Pro)</em>", 'capsman-enhanced' );?>
 			</li>
 
 			<li>
-			<?php _e( "Member support forum", 'capsman-enhanced' );?>
+			<?php esc_html_e( "Member support forum", 'capsman-enhanced' );?>
 			</li>
 
 			</ul></div>
 
 			<?php
 			echo '<div>';
-			printf( __('%1$sgrab%2$s %3$s', 'capsman-enhanced'), '<strong>', '</strong>', '<span class="plugins update-message"><a href="' . cme_plugin_info_url('press-permit-core') . '" class="thickbox" title="' . sprintf( __('%s (free install)', 'capsman-enhanced'), 'Permissions Pro' ) . '">Permissions Pro</a></span>' );
+			printf( esc_html__('%1$sgrab%2$s %3$s', 'capsman-enhanced'), '<strong>', '</strong>', '<span class="plugins update-message"><a href="' . cme_plugin_info_url('press-permit-core') . '" class="thickbox" title="' . sprintf( esc_attr__('%s (free install)', 'capsman-enhanced'), 'Permissions Pro' ) . '">Permissions Pro</a></span>' );
 			echo '&nbsp;&nbsp;&bull;&nbsp;&nbsp;';
-			printf( __('%1$sbuy%2$s %3$s', 'capsman-enhanced'), '<strong>', '</strong>',  '<a href="https://publishpress.com/presspermit/" target="_blank" title="' . sprintf( __('%s info/purchase', 'capsman-enhanced'), 'Permissions Pro' ) . '">Permissions&nbsp;Pro</a>' );
+			printf( esc_html__('%1$sbuy%2$s %3$s', 'capsman-enhanced'), '<strong>', '</strong>',  '<a href="https://publishpress.com/presspermit/" target="_blank" title="' . sprintf( esc_attr__('%s info/purchase', 'capsman-enhanced'), 'Permissions Pro' ) . '">Permissions&nbsp;Pro</a>' );
 			echo '&nbsp;&nbsp;&bull;&nbsp;&nbsp;';
 			echo '<a href="#pp-hide">hide</a>';
 			echo '</div></div>';
@@ -1282,9 +1298,9 @@ if( defined('PRESSPERMIT_ACTIVE') ) {
 			<?php
 			$level = ak_caps2level($rcaps);
 			?>
-			<span title="<?php _e('Role level is mostly deprecated. However, it still determines eligibility for Post Author assignment and limits the application of user editing capabilities.', 'capsman-enhanced');?>">
+			<span title="<?php esc_attr_e('Role level is mostly deprecated. However, it still determines eligibility for Post Author assignment and limits the application of user editing capabilities.', 'capsman-enhanced');?>">
 
-			<?php (in_array(get_locale(), ['en_EN', 'en_US'])) ? printf('Role Level:') : _e('Level:', 'capsman-enhanced');?> <select name="level">
+			<?php (in_array(get_locale(), ['en_EN', 'en_US'])) ? printf('Role Level:') : esc_html_e('Level:', 'capsman-enhanced');?> <select name="level">
 			<?php for ( $l = $this->max_level; $l >= 0; $l-- ) {?>
 					<option value="<?php echo $l; ?>" style="text-align:right;"<?php selected($level, $l); ?>>&nbsp;<?php echo $l; ?>&nbsp;</option>
 				<?php }
@@ -1302,10 +1318,10 @@ if( defined('PRESSPERMIT_ACTIVE') ) {
 		<p class="submit" style="padding-top:0;">
 			<input type="hidden" name="action" value="update" />
 			<input type="hidden" name="current" value="<?php echo $default; ?>" />
-			<input type="submit" name="SaveRole" value="<?php echo (in_array(get_locale(), ['en_EN', 'en_US'])) ? 'Save Capabilities' : _e('Save Changes', 'capsman-enhanced');?>" class="button-primary" /> &nbsp;
+			<input type="submit" name="SaveRole" value="<?php echo (in_array(get_locale(), ['en_EN', 'en_US'])) ? 'Save Capabilities' : esc_html_e('Save Changes', 'capsman-enhanced');?>" class="button-primary" /> &nbsp;
 
 			<?php if ( current_user_can('administrator') && 'administrator' != $default ) : ?>
-				<a class="ak-delete" title="<?php echo esc_attr(__('Delete this role', 'capsman-enhanced')) ?>" href="<?php echo wp_nonce_url("admin.php?page={$this->ID}&amp;action=delete&amp;role={$default}", 'delete-role_' . $default); ?>" onclick="if ( confirm('<?php echo esc_js(sprintf(__("You are about to delete the %s role.\n\n 'Cancel' to stop, 'OK' to delete.", 'capsman-enhanced'), $roles[$default])); ?>') ) { return true;}return false;"><?php _e('Delete Role', 'capsman-enhanced')?></a>
+				<a class="ak-delete" title="<?php echo esc_attr__('Delete this role', 'capsman-enhanced') ?>" href="<?php echo wp_nonce_url("admin.php?page={$this->ID}&amp;action=delete&amp;role={$default}", 'delete-role_' . $default); ?>" onclick="if ( confirm('<?php echo esc_js(sprintf(__("You are about to delete the %s role.\n\n 'Cancel' to stop, 'OK' to delete.", 'capsman-enhanced'), $roles[$default])); ?>') ) { return true;}return false;"><?php esc_html_e('Delete Role', 'capsman-enhanced')?></a>
 			<?php endif; ?>
 		</p>
 
@@ -1314,10 +1330,10 @@ if( defined('PRESSPERMIT_ACTIVE') ) {
 			<?php do_action('publishpress-caps_sidebar_top');?>
 
 			<dl>
-				<dt><?php _e('Add Capability', 'capsman-enhanced'); ?></dt>
+				<dt><?php esc_html_e('Add Capability', 'capsman-enhanced'); ?></dt>
 				<dd style="text-align:center;">
 					<p><input type="text" name="capability-name" class="regular-text" placeholder="<?php echo 'capability_name';?>" /><br />
-					<input type="submit" name="AddCap" value="<?php _e('Add to role', 'capsman-enhanced') ?>" class="button" /></p>
+					<input type="submit" name="AddCap" value="<?php esc_html_e('Add to role', 'capsman-enhanced') ?>" class="button" /></p>
 				</dd>
 			</dl>
 
@@ -1329,28 +1345,28 @@ if( defined('PRESSPERMIT_ACTIVE') ) {
 			?>
 
 			<dl>
-				<dt><?php (!in_array(get_locale(), ['en_EN', 'en_US'])) ? _e('Copy this role to', 'capsman-enhanced') : printf('Copy %s Role', translate_user_role($roles[$default])); ?></dt>
+				<dt><?php (!in_array(get_locale(), ['en_EN', 'en_US'])) ? esc_html_e('Copy this role to', 'capsman-enhanced') : printf('Copy %s Role', translate_user_role($roles[$default])); ?></dt>
 				<dd style="text-align:center;">
 					<?php $class = ( $support_pp_only_roles ) ? 'tight-text' : 'regular-text'; ?>
-					<p><input type="text" name="copy-name"  class="<?php echo $class;?>" placeholder="<?php _e('Role Name', 'capsman-enhanced') ?>" />
+					<p><input type="text" name="copy-name"  class="<?php echo $class;?>" placeholder="<?php esc_html_e('Role Name', 'capsman-enhanced') ?>" />
 
 					<?php if( $support_pp_only_roles ) : ?>
-					<label for="copy_role_pp_only" title="<?php _e('Make role available for supplemental assignment to Permission Groups only', 'capsman-enhanced');?>"> <input type="checkbox" name="copy_role_pp_only" id="copy_role_pp_only" autocomplete="off" value="1"> <?php _e('hidden', 'capsman-enhanced'); ?> </label>
+					<label for="copy_role_pp_only" title="<?php esc_attr_e('Make role available for supplemental assignment to Permission Groups only', 'capsman-enhanced');?>"> <input type="checkbox" name="copy_role_pp_only" id="copy_role_pp_only" autocomplete="off" value="1"> <?php esc_html_e('hidden', 'capsman-enhanced'); ?> </label>
 					<?php endif; ?>
 
 					<br />
-					<input type="submit" name="CopyRole" value="<?php _e('Copy', 'capsman-enhanced') ?>" class="button" />
+					<input type="submit" name="CopyRole" value="<?php esc_html_e('Copy', 'capsman-enhanced') ?>" class="button" />
 					</p>
 				</dd>
 			</dl>
 
 			<dl>
-				<dt><?php _e('Rename Role', 'capsman-enhanced'); ?></dt>
+				<dt><?php esc_html_e('Rename Role', 'capsman-enhanced'); ?></dt>
 				<dd style="text-align:center;">
-					<p><input type="text" name="rename-name" class="regular-text" placeholder="<?php _e('New Role Name', 'capsman-enhanced') ?>" />
+					<p><input type="text" name="rename-name" class="regular-text" placeholder="<?php esc_html_e('New Role Name', 'capsman-enhanced') ?>" />
 
 					<br />
-					<input type="submit" name="RenameRole" value="<?php _e('Rename', 'capsman-enhanced') ?>" class="button" />
+					<input type="submit" name="RenameRole" value="<?php esc_html_e('Rename', 'capsman-enhanced') ?>" class="button" />
 					</p>
 				</dd>
 			</dl>
@@ -1379,13 +1395,13 @@ function cme_network_role_ui( $default ) {
 			$autocreate_roles = array();
 		?>
 		<div style="margin-bottom: 5px">
-		<label for="cme_autocreate_role" title="<?php _e('Create this role definition in new (future) sites', 'capsman-enhanced');?>"><input type="checkbox" name="cme_autocreate_role" id="cme_autocreate_role" autocomplete="off" value="1" <?php echo checked(in_array($default, $autocreate_roles));?>> <?php _e('include in new sites', 'capsman-enhanced'); ?> </label>
+		<label for="cme_autocreate_role" title="<?php esc_attr_e('Create this role definition in new (future) sites', 'capsman-enhanced');?>"><input type="checkbox" name="cme_autocreate_role" id="cme_autocreate_role" autocomplete="off" value="1" <?php echo checked(in_array($default, $autocreate_roles));?>> <?php esc_html_e('include in new sites', 'capsman-enhanced'); ?> </label>
 		</div>
 		<div>
-		<label for="cme_net_sync_role" title="<?php echo esc_attr(__('Copy / update this role definition to all sites now', 'capsman-enhanced'));?>"><input type="checkbox" name="cme_net_sync_role" id="cme_net_sync_role" autocomplete="off" value="1"> <?php _e('sync role to all sites now', 'capsman-enhanced'); ?> </label>
+		<label for="cme_net_sync_role" title="<?php echo esc_attr(esc_html__('Copy / update this role definition to all sites now', 'capsman-enhanced'));?>"><input type="checkbox" name="cme_net_sync_role" id="cme_net_sync_role" autocomplete="off" value="1"> <?php esc_html_e('sync role to all sites now', 'capsman-enhanced'); ?> </label>
 		</div>
 		<div>
-		<label for="cme_net_sync_options" title="<?php echo esc_attr(__('Copy option settings to all sites now', 'capsman-enhanced'));?>"><input type="checkbox" name="cme_net_sync_options" id="cme_net_sync_options" autocomplete="off" value="1"> <?php _e('sync options to all sites now', 'capsman-enhanced'); ?> </label>
+		<label for="cme_net_sync_options" title="<?php echo esc_attr(esc_html__('Copy option settings to all sites now', 'capsman-enhanced'));?>"><input type="checkbox" name="cme_net_sync_options" id="cme_net_sync_options" autocomplete="off" value="1"> <?php esc_html_e('sync options to all sites now', 'capsman-enhanced'); ?> </label>
 		</div>
 	</div>
 <?php

--- a/includes/backup-handler.php
+++ b/includes/backup-handler.php
@@ -12,7 +12,7 @@ class Capsman_BackupHandler
 
 	function __construct( $manager_obj ) {
 		if ((!is_multisite() || !is_super_admin()) && !current_user_can('administrator') && !current_user_can('restore_roles'))
-			wp_die( __( 'You do not have permission to restore roles.', 'capsman-enhanced' ) );
+			wp_die( esc_html__( 'You do not have permission to restore roles.', 'capsman-enhanced' ) );
 	
 		$this->cm = $manager_obj;
 	}
@@ -112,7 +112,7 @@ class Capsman_BackupHandler
 		populate_roles();
 		$this->cm->setAdminCapability();
 
-		$msg = __('Roles and Capabilities reset to WordPress defaults', 'capsman-enhanced');
+		$msg = esc_html__('Roles and Capabilities reset to WordPress defaults', 'capsman-enhanced');
 		
 		if ( function_exists( 'pp_populate_roles' ) ) {
 			pp_populate_roles();

--- a/includes/backup.php
+++ b/includes/backup.php
@@ -36,7 +36,7 @@ $auto_backups = $wpdb->get_results("SELECT option_name, option_value FROM $wpdb-
 
 <div class="wrap publishpress-caps-manage publishpress-caps-backup pressshack-admin-wrapper">
     <div id="icon-capsman-admin" class="icon32"></div>
-    <h2><?php printf(__('Backup Tool for %1$sPublishPress Capabilities%2$s', 'capsman-enhanced'), '<a href="admin.php?page=pp-capabilities">', '</a>'); ?></h2>
+    <h2><?php printf(esc_html__('Backup Tool for %1$sPublishPress Capabilities%2$s', 'capsman-enhanced'), '<a href="admin.php?page=pp-capabilities">', '</a>'); ?></h2>
 
 
     <form method="post" action="admin.php?page=pp-capabilities-backup">
@@ -45,9 +45,9 @@ $auto_backups = $wpdb->get_results("SELECT option_name, option_value FROM $wpdb-
         <div class="pp-columns-wrapper<?php echo defined('CAPSMAN_PERMISSIONS_INSTALLED') && !CAPSMAN_PERMISSIONS_INSTALLED ? ' pp-enable-sidebar' : '' ?>">
             <div class="pp-column-left">
                 <ul id="publishpress-capability-backup-tabs" class="nav-tab-wrapper">
-                    <li class="nav-tab nav-tab-active"><a href="#ppcb-tab-restore"><?php _e('Restore', 'capsman-enhanced');?></a></li>
-                    <li class="nav-tab"><a href="#ppcb-tab-backup"><?php _e('Backup', 'capsman-enhanced');?></a></li>
-                    <li class="nav-tab"><a href="#ppcb-tab-reset"><?php _e('Reset Roles', 'capsman-enhanced');?></a></li>
+                    <li class="nav-tab nav-tab-active"><a href="#ppcb-tab-restore"><?php esc_html_e('Restore', 'capsman-enhanced');?></a></li>
+                    <li class="nav-tab"><a href="#ppcb-tab-backup"><?php esc_html_e('Backup', 'capsman-enhanced');?></a></li>
+                    <li class="nav-tab"><a href="#ppcb-tab-reset"><?php esc_html_e('Reset Roles', 'capsman-enhanced');?></a></li>
                 </ul>
 
                 <fieldset>
@@ -56,22 +56,22 @@ $auto_backups = $wpdb->get_results("SELECT option_name, option_value FROM $wpdb-
                             <td class="content">
 
                                 <dl id="ppcb-tab-backup" style="display:none;">
-                                    <dt><?php _e('Backup Roles and Capabilities', 'capsman-enhanced'); ?></dt>
+                                    <dt><?php esc_html_e('Backup Roles and Capabilities', 'capsman-enhanced'); ?></dt>
                                     <dd>
                                         <p class="description">
                                         <?php
                                         $max_auto_backups = (defined('CME_AUTOBACKUPS')) ? (int) CME_AUTOBACKUPS : 20;
-                                        printf(__('PublishPress Capabilities automatically creates a backup on installation and whenever you save changes. The initial backup and last %d auto-backups are kept.', 'capsman-enhanced'), $max_auto_backups);
+                                        printf(esc_html__('PublishPress Capabilities automatically creates a backup on installation and whenever you save changes. The initial backup and last %d auto-backups are kept.', 'capsman-enhanced'), $max_auto_backups);
                                         ?>
                                         </p>
 
                                         <p class="description">
-                                        <?php _e('A backup created on this screen replaces any previous manual backups, but is never automatically replaced.', 'capsman-enhanced');?>
+                                        <?php esc_html_e('A backup created on this screen replaces any previous manual backups, but is never automatically replaced.', 'capsman-enhanced');?>
                                         </p>
 
                                         <div class="pp-caps-backup-button">
                                             <input type="submit" name="save_backup"
-                                                    value="<?php _e('Manual Backup', 'capsman-enhanced') ?>"
+                                                    value="<?php esc_html_e('Manual Backup', 'capsman-enhanced') ?>"
                                                     class="button-primary"/>
                                         </div>
                                     </dd>
@@ -81,23 +81,23 @@ $auto_backups = $wpdb->get_results("SELECT option_name, option_value FROM $wpdb-
                                 <?php
                                 $listed_manual_backup = false;
                                 $backup_datestamp = get_option('capsman_backup_datestamp');
-                                $last_caption = ($backup_datestamp) ? sprintf(__('Last Manual Backup - %s', 'capsman-enhanced'), date('j M Y, g:i a', $backup_datestamp)) : __('Last Backup', 'capsman-enhanced');
+                                $last_caption = ($backup_datestamp) ? sprintf(esc_html__('Last Manual Backup - %s', 'capsman-enhanced'), date('j M Y, g:i a', $backup_datestamp)) : esc_html__('Last Backup', 'capsman-enhanced');
                                 ?>
 
                                 <dl id="ppcb-tab-restore">
-                                    <dt><?php _e('Restore Previous Roles and Capabilities', 'capsman-enhanced'); ?></dt>
+                                    <dt><?php esc_html_e('Restore Previous Roles and Capabilities', 'capsman-enhanced'); ?></dt>
                                     <dd>
                                         <p class="description">
-                                        <?php _e('PublishPress Capabilities automatically creates a backup on installation and whenever you save changes.', 'capsman-enhanced');?>
+                                        <?php esc_html_e('PublishPress Capabilities automatically creates a backup on installation and whenever you save changes.', 'capsman-enhanced');?>
                                         </p>
 
                                         <p class="description">
-                                        <?php _e('On this screen, you can restore an earlier version of your roles and capabilities.', 'capsman-enhanced');?>
+                                        <?php esc_html_e('On this screen, you can restore an earlier version of your roles and capabilities.', 'capsman-enhanced');?>
                                         </p>
 
                                         <table width='100%' class="form-table">
                                             <tr>
-                                                <th scope="row"><?php _e('Available Backups:', 'capsman-enhanced'); ?></th>
+                                                <th scope="row"><?php esc_html_e('Available Backups:', 'capsman-enhanced'); ?></th>
                                                 <td>
                                                     <div id="cme_select_restore_div">
                                                     <ul id="cme_select_restore">
@@ -111,7 +111,7 @@ $auto_backups = $wpdb->get_results("SELECT option_name, option_value FROM $wpdb-
                                                             ?>
                                                                 <li>
                                                                 <input type="radio" name="select_restore" value="restore" id="cme_restore_manual">
-                                                                <label for="cme_restore_manual"><?php printf(__('Manual backup of all roles (%s)', 'capsman-enhanced'), $manual_date_caption); ?></label>
+                                                                <label for="cme_restore_manual"><?php printf(esc_html__('Manual backup of all roles (%s)', 'capsman-enhanced'), $manual_date_caption); ?></label>
                                                                 </li>
                                                                 <?php
                                                                 $listed_manual_backup = true;
@@ -125,8 +125,8 @@ $auto_backups = $wpdb->get_results("SELECT option_name, option_value FROM $wpdb-
                                                             ?>
 
                                                             <li>
-                                                            <input type="radio" name="select_restore" value="<?php echo $row->option_name;?>" id="<?php echo $row->option_name;?>">
-                                                            <label for="<?php echo $row->option_name;?>"><?php printf(__('Auto-backup of all roles (%s)', 'capsman-enhanced'), $date_caption); ?></label>
+                                                            <input type="radio" name="select_restore" value="<?php echo esc_attr($row->option_name);?>" id="<?php echo esc_attr($row->option_name);?>">
+                                                            <label for="<?php echo esc_attr($row->option_name);?>"><?php printf(esc_html__('Auto-backup of all roles (%s)', 'capsman-enhanced'), $date_caption); ?></label>
                                                             </li>
                                                         <?php endforeach; ?>
 
@@ -134,7 +134,7 @@ $auto_backups = $wpdb->get_results("SELECT option_name, option_value FROM $wpdb-
                                                         if ($initial = get_option('capsman_backup_initial')):?>
                                                             <li>
                                                             <input type="radio" name="select_restore" value="restore_initial" id="cme_restore_initial">
-                                                            <label for="cme_restore_initial"><?php _e('Initial backup of all roles', 'capsman-enhanced'); ?></label>
+                                                            <label for="cme_restore_initial"><?php esc_html_e('Initial backup of all roles', 'capsman-enhanced'); ?></label>
                                                             </li>
                                                         <?php endif; ?>
                                                     <!-- </select> -->
@@ -143,7 +143,7 @@ $auto_backups = $wpdb->get_results("SELECT option_name, option_value FROM $wpdb-
 
                                                     <div class="cme-restore-button">
                                                     <input type="submit" name="restore_backup"
-                                                           value="<?php _e('Restore Selected Roles', 'capsman-enhanced') ?>"
+                                                           value="<?php esc_html_e('Restore Selected Roles', 'capsman-enhanced') ?>"
                                                            class="button-primary"/>
 
                                                     <div class="cme-selected-backup-caption">
@@ -154,13 +154,13 @@ $auto_backups = $wpdb->get_results("SELECT option_name, option_value FROM $wpdb-
 
                                                 <td class="cme-backup-info">
                                                     <div class="cme_backup_info_changes_only" style="display:none">
-                                                    <input type="checkbox" class="cme_backup_info_changes_only" autocomplete="off" checked="checked"> <?php _e('Show changes from current roles only', 'capsman-enhanced');?>
+                                                    <input type="checkbox" class="cme_backup_info_changes_only" autocomplete="off" checked="checked"> <?php esc_html_e('Show changes from current roles only', 'capsman-enhanced');?>
                                                     </div>
 
                                                 <?php
                                                     global $wp_roles;
 
-                                                    $initial_caption = ($backup_datestamp = get_option('capsman_backup_initial_datestamp')) ? sprintf(__('Initial Backup - %s', 'capsman-enhanced'), date('j M Y, g:i a', $backup_datestamp)) : __('Initial Backup', 'capsman-enhanced');
+                                                    $initial_caption = ($backup_datestamp = get_option('capsman_backup_initial_datestamp')) ? sprintf(esc_html__('Initial Backup - %s', 'capsman-enhanced'), date('j M Y, g:i a', $backup_datestamp)) : esc_html__('Initial Backup', 'capsman-enhanced');
 
                                                     $backups = array(
                                                         'capsman_backup_initial' => $initial_caption,
@@ -178,7 +178,8 @@ $auto_backups = $wpdb->get_results("SELECT option_name, option_value FROM $wpdb-
                                                         $date_caption = str_replace(' ', ', ', $date_caption);
                                                         $date_caption = str_replace(', am', ' am', $date_caption);
                                                         $date_caption = str_replace(', pm', ' pm', $date_caption);
-
+                                                        
+                                                        $option_name = sanitize_key($row->option_name);
                                                         $backups[$row->option_name] = "Auto-backup from " . $date_caption;
                                                     }
 
@@ -186,7 +187,7 @@ $auto_backups = $wpdb->get_results("SELECT option_name, option_value FROM $wpdb-
                                                         if ($backup_data = get_option($name)) :?>
                                                             <div id="cme_display_<?php echo $name; ?>" style="display:none;"
                                                                 class="cme-show-backup">
-                                                                <h3><?php printf(__("%s (%s roles)", 'capsman-enhanded'), $caption, count($backup_data)); ?></h3>
+                                                                <h3><?php printf(esc_html__("%s (%s roles)", 'capsman-enhanded'), $caption, count($backup_data)); ?></h3>
 
                                                                 <?php
                                                                 foreach ($wp_roles->role_objects as $role => $role_object) {
@@ -194,7 +195,7 @@ $auto_backups = $wpdb->get_results("SELECT option_name, option_value FROM $wpdb-
                                                                         $role_caption = $role_object->name;
                                                                         $role_class = ' class="cme-change cme-minus"';
                                                                         ?>
-                                                                        <h4><span<?php echo $role_class;?>><?php echo (translate_user_role($role_caption));?></span> <?php _e('(this role will be removed if you restore backup)', 'capsman-enhanced');?></h4>
+                                                                        <h4><span<?php echo $role_class;?>><?php echo (translate_user_role($role_caption));?></span> <?php esc_html_e('(this role will be removed if you restore backup)', 'capsman-enhanced');?></h4>
                                                                         <?php
                                                                     }
                                                                 }
@@ -223,7 +224,7 @@ $auto_backups = $wpdb->get_results("SELECT option_name, option_value FROM $wpdb-
                                                                     $role_class = (empty($wp_roles->role_objects[$role])) ? ' class="cme-change cme-plus"' : '';
                                                                     ?>
 
-                                                                    <h4<?php echo $role_class;?>><?php printf(__('%s (level %s)', 'capsman-enhanced'), translate_user_role($role_caption), $level); ?></h4>
+                                                                    <h4<?php echo $role_class;?>><?php printf(esc_html__('%s (level %s)', 'capsman-enhanced'), translate_user_role($role_caption), $level); ?></h4>
 
                                                                     <?php
                                                                     $items = [];
@@ -263,7 +264,7 @@ $auto_backups = $wpdb->get_results("SELECT option_name, option_value FROM $wpdb-
 
                                                                     <?php if (!$any_changes):?>
                                                                         <span class="pp-restore-caps-no-change">
-                                                                        <?php _e('No changes', 'capsman-enhanced');?>
+                                                                        <?php esc_html_e('No changes', 'capsman-enhanced');?>
                                                                         </span>
                                                                     <?php endif;?>
                                                                 <?php endforeach; ?>
@@ -279,20 +280,20 @@ $auto_backups = $wpdb->get_results("SELECT option_name, option_value FROM $wpdb-
 
 
                                 <dl id="ppcb-tab-reset" style="display:none;">
-                                    <dt><?php if (!in_array(get_locale(), ['en_EN', 'en_US'])) _e('Reset WordPress Defaults', 'capsman-enhanced'); else echo 'Reset Roles to WordPress Defaults'; ?></dt>
+                                    <dt><?php if (!in_array(get_locale(), ['en_EN', 'en_US'])) esc_html_e('Reset WordPress Defaults', 'capsman-enhanced'); else echo 'Reset Roles to WordPress Defaults'; ?></dt>
                                     <dd>
-                                        <p><strong><span class="pp-caps-warning"><?php _e('WARNING:', 'capsman-enhanced'); ?></span> <?php if (!in_array(get_locale(), ['en_EN', 'en_US'])) _e('Reseting default Roles and Capabilities will set them to the WordPress install defaults.', 'capsman-enhanced'); else echo 'This will delete and/or modify stored role definitions.'; ?>
+                                        <p><strong><span class="pp-caps-warning"><?php esc_html_e('WARNING:', 'capsman-enhanced'); ?></span> <?php if (!in_array(get_locale(), ['en_EN', 'en_US'])) esc_html_e('Reseting default Roles and Capabilities will set them to the WordPress install defaults.', 'capsman-enhanced'); else echo 'This will delete and/or modify stored role definitions.'; ?>
                                             </strong><br/>
                                             <br/>
                                             <?php
-                                            _e('If you have installed any plugin that adds new roles or capabilities, these will be lost.', 'capsman-enhanced') ?>
+                                            esc_html_e('If you have installed any plugin that adds new roles or capabilities, these will be lost.', 'capsman-enhanced') ?>
                                             <br/>
-                                            <strong><?php if (!in_array(get_locale(), ['en_EN', 'en_US'])) _e('It is recommended to use this only as a last resource!', 'capsman-enhanced'); else echo('It is recommended to use this only as a last resort!'); ?></strong>
+                                            <strong><?php if (!in_array(get_locale(), ['en_EN', 'en_US'])) esc_html_e('It is recommended to use this only as a last resource!', 'capsman-enhanced'); else echo('It is recommended to use this only as a last resort!'); ?></strong>
                                         </p>
                                         <p><a class="ak-delete button-primary"
-                                                                         title="<?php echo esc_attr(__('Reset Roles and Capabilities to WordPress defaults', 'capsman-enhanced')) ?>"
+                                                                         title="<?php echo esc_attr__('Reset Roles and Capabilities to WordPress defaults', 'capsman-enhanced') ?>"
                                                                          href="<?php echo wp_nonce_url("admin.php?page=pp-capabilities-backup&amp;action=reset-defaults", 'capsman-reset-defaults'); ?>"
-                                                                         onclick="if ( confirm('<?php echo esc_js(__("You are about to reset Roles and Capabilities to WordPress defaults.\n 'Cancel' to stop, 'OK' to reset.", 'capsman-enhanced')); ?>') ) { return true;}return false;"><?php _e('Reset to WordPress defaults', 'capsman-enhanced') ?></a>
+                                                                         onclick="if ( confirm('<?php echo esc_js(__("You are about to reset Roles and Capabilities to WordPress defaults.\n 'Cancel' to stop, 'OK' to reset.", 'capsman-enhanced')); ?>') ) { return true;}return false;"><?php esc_html_e('Reset to WordPress defaults', 'capsman-enhanced') ?></a>
 
                                     </dd>
                                 </dl>
@@ -308,15 +309,15 @@ $auto_backups = $wpdb->get_results("SELECT option_name, option_value FROM $wpdb-
                     <?php
                     $banners = new PublishPress\WordPressBanners\BannersMain;
                     $banners->pp_display_banner(
-                        __( 'Recommendations for you', 'capsman-enhanced' ),
-                        __( 'Control permissions for individual posts and pages', 'capsman-enhanced' ),
+                        esc_html__( 'Recommendations for you', 'capsman-enhanced' ),
+                        esc_html__( 'Control permissions for individual posts and pages', 'capsman-enhanced' ),
                         array(
-                            __( 'Choose who can read and edit each post.', 'capsman-enhanced' ),
-                            __( 'Allow specific user roles or users to manage each post.', 'capsman-enhanced' ),
-                            __( 'PublishPress Permissions is 100% free to install.', 'capsman-enhanced' )
+                            esc_html__( 'Choose who can read and edit each post.', 'capsman-enhanced' ),
+                            esc_html__( 'Allow specific user roles or users to manage each post.', 'capsman-enhanced' ),
+                            esc_html__( 'PublishPress Permissions is 100% free to install.', 'capsman-enhanced' )
                         ),
                         admin_url( 'plugin-install.php?s=publishpress-ppcore-install&tab=search&type=term' ),
-                        __( 'Click here to install PublishPress Permissions', 'capsman-enhanced' ),
+                        esc_html__( 'Click here to install PublishPress Permissions', 'capsman-enhanced' ),
                         'install-permissions.jpg'
                     );
                     ?>

--- a/includes/features/admin-features.php
+++ b/includes/features/admin-features.php
@@ -184,7 +184,15 @@ $admin_features_elements = PP_Capabilities_Admin_Features::elementsLayout();
                                                                                     }
                                                                                 }
                                                                                 ?>
-                                                                                <?php echo esc_html($item_name); ?>
+                                                                                <?php 
+                                                                                if(isset($section_array['custom_element']) && ($section_array['custom_element'] === true)){
+                                                                                    $delete_button = '<span class="' . esc_attr($section_array['button_class'])  . '" data-id="' . esc_attr($section_array['button_data_id'])  . '"><small>(' . __('Delete', 'capabilities-pro') . ')</small></span>';
+
+                                                                                    echo esc_html($section_array['element_label']) . ' <small class="entry">(' . esc_html($section_array['element_items']). ')</small> &nbsp; ' . $delete_button . '';
+                                                                                }else{
+                                                                                    echo esc_html($item_name);
+                                                                                }
+                                                                                ?>
                                                                             </strong></span>
                                                                         </label>
                                                                     </td>

--- a/includes/features/admin-features.php
+++ b/includes/features/admin-features.php
@@ -34,7 +34,7 @@ $admin_features_elements = PP_Capabilities_Admin_Features::elementsLayout();
 
     <div class="wrap publishpress-caps-manage pressshack-admin-wrapper pp-capability-menus-wrapper">
         <div id="icon-capsman-admin" class="icon32"></div>
-        <h2><?php _e('Admin Feature Restrictions', 'capabilities-pro'); ?></h2>
+        <h2><?php esc_html_e('Admin Feature Restrictions', 'capabilities-pro'); ?></h2>
 
         <form method="post" id="ppc-admin-features-form" action="admin.php?page=pp-capabilities-admin-features">
             <?php wp_nonce_field('pp-capabilities-admin-features'); ?>
@@ -50,7 +50,7 @@ $admin_features_elements = PP_Capabilities_Admin_Features::elementsLayout();
                                     <span class="cme-subtext">
                                     <span class='pp-capability-role-caption'>
                                     <?php
-                                    _e('Note: You are only restricting access to admin features screens. Some plugins may also add features to other areas of WordPress.',
+                                    esc_html_e('Note: You are only restricting access to admin features screens. Some plugins may also add features to other areas of WordPress.',
                                         'capabilities-pro');
                                     ?>
                                     </span>
@@ -62,8 +62,8 @@ $admin_features_elements = PP_Capabilities_Admin_Features::elementsLayout();
                                             foreach ($roles as $role => $name) :
                                                 $name = translate_user_role($name);
                                                 ?>
-                                                <option value="<?php echo $role; ?>" <?php selected($default_role,
-                                                    $role); ?>><?php echo $name; ?></option>
+                                                <option value="<?php echo esc_attr($role); ?>" <?php selected($default_role,
+                                                    $role); ?>><?php echo esc_html($name); ?></option>
                                             <?php
                                             endforeach;
                                             ?>
@@ -73,7 +73,7 @@ $admin_features_elements = PP_Capabilities_Admin_Features::elementsLayout();
                                              style="display: none">
 
                                         <input type="submit" name="admin-features-submit"
-                                               value="<?php _e('Save Changes', 'capabilities-pro') ?>"
+                                               value="<?php esc_html_e('Save Changes', 'capabilities-pro') ?>"
                                                class="button-primary ppc-admin-features-submit" style="float:right"/>
                                     </div>
 
@@ -109,7 +109,7 @@ $admin_features_elements = PP_Capabilities_Admin_Features::elementsLayout();
                                                         foreach ($admin_features_elements as $section_title => $section_elements) :
                                                             $sn++;
                                                             $section_slug = strtolower(ppc_remove_non_alphanumeric_space_characters($section_title));
-                                                            $icon_name    = isset($icon_list[$section_slug]) ? $icon_list[$section_slug] : '&mdash;';
+                                                            $icon_name    = isset($icon_list[$section_slug]) ? esc_attr($icon_list[$section_slug]) : '&mdash;';
                                                             ?>
 
                                                             <tr class="ppc-menu-row parent-menu">
@@ -126,14 +126,14 @@ $admin_features_elements = PP_Capabilities_Admin_Features::elementsLayout();
 		                                                                    <label for="check-item-<?php echo $sn; ?>">
 		                                                            <strong class="menu-column ppc-menu-item menu-item-link<?php echo (in_array($restrict_value,
 		                                                                            $disabled_admin_items)) ? ' restricted' : ''; ?>">
-		                                                                <i class="dashicons dashicons-<?php echo $icon_name ?>"></i> <?php echo $section_title; ?>
+		                                                                <i class="dashicons dashicons-<?php echo $icon_name ?>"></i> <?php echo esc_html($section_title); ?>
 		                                                            </strong>
 		                                                        </label>
 		                                                        </td>
 		                                                        <?php else : ?>
 		                                                                <td class="features-section-header" colspan="2">
 		                                                                    <strong><i
-		                                                                            class="dashicons dashicons-<?php echo $icon_name ?>"></i> <?php echo $section_title; ?>
+		                                                                            class="dashicons dashicons-<?php echo $icon_name ?>"></i> <?php echo esc_html($section_title); ?>
 		                                                                    </strong>
 		                                                                </td>
 		                                                        <?php endif; ?>
@@ -184,7 +184,7 @@ $admin_features_elements = PP_Capabilities_Admin_Features::elementsLayout();
                                                                                     }
                                                                                 }
                                                                                 ?>
-                                                                                <?php echo $item_name; ?>
+                                                                                <?php echo esc_html($item_name); ?>
                                                                             </strong></span>
                                                                         </label>
                                                                     </td>
@@ -205,7 +205,7 @@ $admin_features_elements = PP_Capabilities_Admin_Features::elementsLayout();
                                         </div>
                                     </div>
                                     <input type="submit" name="admin-features-submit"
-                                           value="<?php _e('Save Changes', 'capabilities-pro') ?>"
+                                           value="<?php esc_html_e('Save Changes', 'capabilities-pro') ?>"
                                            class="button-primary ppc-admin-features-submit"/>
                                 </td>
                             </tr>
@@ -218,15 +218,15 @@ $admin_features_elements = PP_Capabilities_Admin_Features::elementsLayout();
                         <?php
                         $banners = new PublishPress\WordPressBanners\BannersMain;
                         $banners->pp_display_banner(
-                            __( 'Recommendations for you', 'capsman-enhanced' ),
-                            __( 'Control permissions for individual posts and pages', 'capsman-enhanced' ),
+                            esc_html__( 'Recommendations for you', 'capsman-enhanced' ),
+                            esc_html__( 'Control permissions for individual posts and pages', 'capsman-enhanced' ),
                             array(
-                                __( 'Choose who can read and edit each post.', 'capsman-enhanced' ),
-                                __( 'Allow specific user roles or users to manage each post.', 'capsman-enhanced' ),
-                                __( 'PublishPress Permissions is 100% free to install.', 'capsman-enhanced' )
+                                esc_html__( 'Choose who can read and edit each post.', 'capsman-enhanced' ),
+                                esc_html__( 'Allow specific user roles or users to manage each post.', 'capsman-enhanced' ),
+                                esc_html__( 'PublishPress Permissions is 100% free to install.', 'capsman-enhanced' )
                             ),
                             admin_url( 'plugin-install.php?s=publishpress-ppcore-install&tab=search&type=term' ),
-                            __( 'Click here to install PublishPress Permissions', 'capsman-enhanced' ),
+                            esc_html__( 'Click here to install PublishPress Permissions', 'capsman-enhanced' ),
                             'install-permissions.jpg'
                         );
                         ?>

--- a/includes/features/editor-features-classic.php
+++ b/includes/features/editor-features-classic.php
@@ -72,7 +72,15 @@ foreach($def_post_types as $post_type) {
                 <td class="menu-column ppc-menu-item">
                     <span class="classic menu-item-link<?php echo (in_array($feature_slug, $ce_post_disabled['post'])) ? ' restricted' : ''; ?>">
                     <strong><i class="dashicons dashicons-arrow-right"></i>
-                        <?php echo esc_html($arr_feature['label']); ?>
+                        <?php 
+                        if(isset($arr_feature['custom_element']) && ($arr_feature['custom_element'] === true)){
+                            $delete_button = '<span class="' . esc_attr($arr_feature['button_class'])  . '" data-id="' . esc_attr($arr_feature['button_data_id'])  . '" data-parent="' . esc_attr($arr_feature['button_data_parent'])  . '"><small>(' . __('Delete', 'capsman-enhanced') . ')</small></span>';
+
+                            echo esc_html($arr_feature['element_label']) . ' <small class="entry">(' . esc_html($arr_feature['element_items']). ')</small> &nbsp; ' . $delete_button . '';
+                        }else{
+                            echo esc_html($arr_feature['label']);
+                        }
+                        ?>
                     </strong></span>
                 </td>
 

--- a/includes/features/editor-features-classic.php
+++ b/includes/features/editor-features-classic.php
@@ -26,13 +26,13 @@ foreach($def_post_types as $post_type) {
     <?php foreach(['thead', 'tfoot'] as $tag):?>
     <<?php echo $tag;?>>
     <tr>
-        <th class="menu-column"><?php if ('thead' == $tag || !defined('PUBLISHPRESS_CAPS_PRO_VERSION')) {_e('Classic Editor Screen', 'capsman-enhanced');}?></th>
+        <th class="menu-column"><?php if ('thead' == $tag || !defined('PUBLISHPRESS_CAPS_PRO_VERSION')) {esc_html_e('Classic Editor Screen', 'capsman-enhanced');}?></th>
 
         <?php foreach($def_post_types as $post_type) :
             $type_obj = get_post_type_object($post_type);    
         ?>
-            <th class="restrict-column ppc-menu-row"><?php printf(__('%s Restrict', 'capsman-enhanced'), $type_obj->labels->singular_name);?><br />
-            <input class="check-item classic check-all-menu-item" type="checkbox" title="<?php _e('Toggle all', 'capsman-enhanced');?>" data-pp_type="<?php echo $post_type;?>" />
+            <th class="restrict-column ppc-menu-row"><?php printf(esc_html__('%s Restrict', 'capsman-enhanced'), $type_obj->labels->singular_name);?><br />
+            <input class="check-item classic check-all-menu-item" type="checkbox" title="<?php esc_attr_e('Toggle all', 'capsman-enhanced');?>" data-pp_type="<?php echo $post_type;?>" />
             </th>
         <?php endforeach;?>
     </tr>
@@ -46,7 +46,7 @@ foreach($def_post_types as $post_type) {
         ?>
         <tr class="ppc-menu-row parent-menu">
             <td colspan="<?php echo (count($def_post_types) + 1);?>">
-            <h4 class="ppc-menu-row-section"><?php echo $section_title;?></h4>
+            <h4 class="ppc-menu-row-section"><?php echo esc_html($section_title);?></h4>
             <?php
             /**
 	         * Add support for section description
@@ -72,7 +72,7 @@ foreach($def_post_types as $post_type) {
                 <td class="menu-column ppc-menu-item">
                     <span class="classic menu-item-link<?php echo (in_array($feature_slug, $ce_post_disabled['post'])) ? ' restricted' : ''; ?>">
                     <strong><i class="dashicons dashicons-arrow-right"></i>
-                        <?php echo $arr_feature['label']; ?>
+                        <?php echo esc_html($arr_feature['label']); ?>
                     </strong></span>
                 </td>
 
@@ -80,7 +80,7 @@ foreach($def_post_types as $post_type) {
                     <td class="restrict-column ppc-menu-checkbox">
                         <input id="cb_<?php echo $post_type . '-' . str_replace(['#', '.'], '_', $feature_slug);?>" class="check-item" type="checkbox"
                                 name="capsman_feature_restrict_classic_<?php echo $post_type;?>[]"
-                                value="<?php echo $feature_slug; ?>" <?php checked(in_array($feature_slug, $ce_post_disabled[$post_type]));?> />
+                                value="<?php echo esc_attr($feature_slug); ?>" <?php checked(in_array($feature_slug, $ce_post_disabled[$post_type]));?> />
                     </td>
                 <?php endforeach;?>
             </tr>

--- a/includes/features/editor-features-gutenberg.php
+++ b/includes/features/editor-features-gutenberg.php
@@ -71,7 +71,15 @@ foreach($def_post_types as $post_type) {
             <td class="menu-column ppc-menu-item">
                 <span class="gutenberg menu-item-link<?php checked(in_array($feature_slug, $gutenberg_post_disabled['post']), true, 'restricted');?>">
                 <strong><i class="dashicons dashicons-arrow-right"></i>
-                    <?php echo esc_html($arr_feature['label']); ?>
+                    <?php 
+                    if(isset($arr_feature['custom_element']) && ($arr_feature['custom_element'] === true)){
+                        $delete_button = '<span class="' . esc_attr($arr_feature['button_class'])  . '" data-id="' . esc_attr($arr_feature['button_data_id'])  . '" data-parent="' . esc_attr($arr_feature['button_data_parent'])  . '"><small>(' . __('Delete', 'capsman-enhanced') . ')</small></span>';
+
+                        echo esc_html($arr_feature['element_label']) . ' <small class="entry">(' . esc_html($arr_feature['element_items']). ')</small> &nbsp; ' . $delete_button . '';
+                    }else{
+                        echo esc_html($arr_feature['label']);
+                    }
+                    ?>
                 </strong></span>
             </td>
 

--- a/includes/features/editor-features-gutenberg.php
+++ b/includes/features/editor-features-gutenberg.php
@@ -26,13 +26,13 @@ foreach($def_post_types as $post_type) {
     <?php foreach(['thead', 'tfoot'] as $tag):?>
     <<?php echo $tag;?>>
     <tr>
-        <th class="menu-column"><?php if ('thead' == $tag) {_e('Gutenberg Screen', 'capsman-enhanced');}?></th>
+        <th class="menu-column"><?php if ('thead' == $tag) {esc_html_e('Gutenberg Screen', 'capsman-enhanced');}?></th>
 
         <?php foreach($def_post_types as $post_type) :
             $type_obj = get_post_type_object($post_type);
         ?>
-            <th class="restrict-column ppc-menu-row"><?php printf(__('%s Restrict', 'capsman-enhanced'), $type_obj->labels->singular_name);?><br />
-            <input class="check-item gutenberg check-all-menu-item" type="checkbox" title="<?php _e('Toggle all', 'capsman-enhanced');?>" data-pp_type="<?php echo $post_type;?>" />
+            <th class="restrict-column ppc-menu-row"><?php printf(esc_html__('%s Restrict', 'capsman-enhanced'), $type_obj->labels->singular_name);?><br />
+            <input class="check-item gutenberg check-all-menu-item" type="checkbox" title="<?php esc_attr_e('Toggle all', 'capsman-enhanced');?>" data-pp_type="<?php echo $post_type;?>" />
             </th>
         <?php endforeach;?>
     </tr>
@@ -46,7 +46,7 @@ foreach($def_post_types as $post_type) {
         ?>
         <tr class="ppc-menu-row parent-menu">
             <td colspan="<?php echo (count($def_post_types) + 1);?>">
-            <h4 class="ppc-menu-row-section"><?php echo $section_title;?></h4>
+            <h4 class="ppc-menu-row-section"><?php echo esc_html($section_title);?></h4>
             <?php
             /**
 	         * Add support for section description
@@ -64,12 +64,14 @@ foreach($def_post_types as $post_type) {
 
         <?php
         foreach ($arr as $feature_slug => $arr_feature) {
+            $feature_slug = esc_attr($feature_slug);
+
         ?>
         <tr class="ppc-menu-row parent-menu">
             <td class="menu-column ppc-menu-item">
                 <span class="gutenberg menu-item-link<?php checked(in_array($feature_slug, $gutenberg_post_disabled['post']), true, 'restricted');?>">
                 <strong><i class="dashicons dashicons-arrow-right"></i>
-                    <?php echo $arr_feature['label']; ?>
+                    <?php echo esc_html($arr_feature['label']); ?>
                 </strong></span>
             </td>
 

--- a/includes/features/editor-features.php
+++ b/includes/features/editor-features.php
@@ -29,7 +29,7 @@ $classic_editor = pp_capabilities_is_classic_editor_available();
 ?>
 <div class="wrap publishpress-caps-manage pressshack-admin-wrapper pp-capability-menus-wrapper">
     <div id="icon-capsman-admin" class="icon32"></div>
-    <h2><?php _e('Editor Feature Restriction', 'capsman-enhanced'); ?></h2>
+    <h2><?php esc_html_e('Editor Feature Restriction', 'capsman-enhanced'); ?></h2>
 
     <form method="post" id="ppc-editor-features-form"
             action="admin.php?page=pp-capabilities-editor-features">
@@ -45,7 +45,7 @@ $classic_editor = pp_capabilities_is_classic_editor_available();
                                 <span class="cme-subtext">
                                 <span class='pp-capability-role-caption'>
                                 <?php
-                                _e('Select editor features to remove. Note that this screen cannot be used to grant additional features to any role.', 'capabilities-pro');
+                                esc_html_e('Select editor features to remove. Note that this screen cannot be used to grant additional features to any role.', 'capabilities-pro');
                                 ?>
                                 </span>
                                 </span>
@@ -57,7 +57,7 @@ $classic_editor = pp_capabilities_is_classic_editor_available();
                                     foreach ($roles as $role => $name) :
                                         $name = translate_user_role($name);
                                         ?>
-                                        <option value="<?php echo $role;?>" <?php selected($default_role, $role);?>><?php echo $name;?></option>
+                                        <option value="<?php echo esc_attr($role);?>" <?php selected($default_role, $role);?>><?php echo esc_html($name);?></option>
                                     <?php
                                     endforeach;
                                     ?>
@@ -66,7 +66,7 @@ $classic_editor = pp_capabilities_is_classic_editor_available();
                                 <img class="loading" src="<?php echo $capsman->mod_url; ?>/images/wpspin_light.gif" style="display: none">
 
                                 <input type="submit" name="editor-features-submit"
-                                    value="<?php _e('Save Changes', 'capabilities-pro') ?>"
+                                    value="<?php esc_html_e('Save Changes', 'capabilities-pro') ?>"
                                     class="button-primary ppc-editor-features-submit" style="float:right" />
 
                                 <input type="hidden" name="ppc-tab" value="<?php echo (!empty($_REQUEST['ppc-tab'])) ? sanitize_key($_REQUEST['ppc-tab']) : 'gutenberg';?>" />
@@ -89,10 +89,10 @@ $classic_editor = pp_capabilities_is_classic_editor_available();
                             <?php if ($classic_editor) { ?>
                                 <ul class="nav-tab-wrapper">
                                     <li class="editor-features-tab gutenberg-tab nav-tab <?php if (empty($_REQUEST['ppc-tab']) || ('gutenberg' == $_REQUEST['ppc-tab'])) echo 'nav-tab-active';?>"
-                                        data-tab=".editor-features-gutenberg"><a href="#"><?php _e('Gutenberg', 'capsman-enhanced') ?></a></li>
+                                        data-tab=".editor-features-gutenberg"><a href="#"><?php esc_html_e('Gutenberg', 'capsman-enhanced') ?></a></li>
 
                                     <li class="editor-features-tab classic-tab nav-tab <?php if (!empty($_REQUEST['ppc-tab']) && ('classic' == $_REQUEST['ppc-tab'])) echo 'nav-tab-active';?>"
-                                        data-tab=".editor-features-classic"><a href="#"><?php _e('Classic', 'capsman-enhanced') ?></a></li>
+                                        data-tab=".editor-features-classic"><a href="#"><?php esc_html_e('Classic', 'capsman-enhanced') ?></a></li>
                                 </ul>
                             <?php } ?>
 
@@ -119,7 +119,7 @@ $classic_editor = pp_capabilities_is_classic_editor_available();
                             </div>
 
                             <input type="submit" name="editor-features-submit"
-                                    value="<?php _e('Save Changes', 'capsman-enhanced') ?>"
+                                    value="<?php esc_html_e('Save Changes', 'capsman-enhanced') ?>"
                                     class="button-primary ppc-editor-features-submit"/> &nbsp;
 
 
@@ -132,15 +132,15 @@ $classic_editor = pp_capabilities_is_classic_editor_available();
                     <?php
                     $banners = new PublishPress\WordPressBanners\BannersMain;
                     $banners->pp_display_banner(
-                        __( 'Recommendations for you', 'capsman-enhanced' ),
-                        __( 'Control permissions for individual posts and pages', 'capsman-enhanced' ),
+                        esc_html__( 'Recommendations for you', 'capsman-enhanced' ),
+                        esc_html__( 'Control permissions for individual posts and pages', 'capsman-enhanced' ),
                         array(
-                            __( 'Choose who can read and edit each post.', 'capsman-enhanced' ),
-                            __( 'Allow specific user roles or users to manage each post.', 'capsman-enhanced' ),
-                            __( 'PublishPress Permissions is 100% free to install.', 'capsman-enhanced' )
+                            esc_html__( 'Choose who can read and edit each post.', 'capsman-enhanced' ),
+                            esc_html__( 'Allow specific user roles or users to manage each post.', 'capsman-enhanced' ),
+                            esc_html__( 'PublishPress Permissions is 100% free to install.', 'capsman-enhanced' )
                         ),
                         admin_url( 'plugin-install.php?s=publishpress-ppcore-install&tab=search&type=term' ),
-                        __( 'Click here to install PublishPress Permissions', 'capsman-enhanced' ),
+                        esc_html__( 'Click here to install PublishPress Permissions', 'capsman-enhanced' ),
                         'install-permissions.jpg'
                     );
                     ?>

--- a/includes/features/restrict-admin-features.php
+++ b/includes/features/restrict-admin-features.php
@@ -13,13 +13,13 @@ class PP_Capabilities_Admin_Features
         $elements = [];
 
         //Add header and footer
-        $elements[__('Header and Footer', 'capsman-enhanced')] = self::formatHeaderFooter();
+        $elements[esc_html__('Header and Footer', 'capsman-enhanced')] = self::formatHeaderFooter();
 
         //Add toolbar
-        $elements[__('Admin Toolbar', 'capsman-enhanced')] = self::formatAdminToolbar();
+        $elements[esc_html__('Admin Toolbar', 'capsman-enhanced')] = self::formatAdminToolbar();
 
         //Add dashboard widget
-        $elements[__('Dashboard widgets', 'capsman-enhanced')] = self::formatDashboardWidgets();
+        $elements[esc_html__('Dashboard widgets', 'capsman-enhanced')] = self::formatDashboardWidgets();
 
         return apply_filters('pp_capabilities_admin_features_elements', $elements);
     }
@@ -56,17 +56,17 @@ class PP_Capabilities_Admin_Features
     {
         $title = [];
 
-        $title['menu-toggle']      = __('Mobile Menu Toggle', 'capsman-enhanced');
-        $title['wp-logo']          = __('WordPress Logo', 'capsman-enhanced');
-        $title['wp-logo-external'] = __('WordPress External Links', 'capsman-enhanced');
-        $title['updates']          = __('Updates', 'capsman-enhanced');
-        $title['comments']         = __('Comments', 'capsman-enhanced');
-        $title['top-secondary']    = __('Right bar', 'capsman-enhanced');
-        $title['user-actions']     = __('User actions', 'capsman-enhanced');
-        $title['new-content']      = __('New', 'capsman-enhanced');
-        $title['new-content']      = __('New', 'capsman-enhanced');
-        $title['user-info']        = __('User Display Name', 'capsman-enhanced');
-        $title['wpseo-menu']       = __('Yoast SEO', 'capsman-enhanced');
+        $title['menu-toggle']      = esc_html__('Mobile Menu Toggle', 'capsman-enhanced');
+        $title['wp-logo']          = esc_html__('WordPress Logo', 'capsman-enhanced');
+        $title['wp-logo-external'] = esc_html__('WordPress External Links', 'capsman-enhanced');
+        $title['updates']          = esc_html__('Updates', 'capsman-enhanced');
+        $title['comments']         = esc_html__('Comments', 'capsman-enhanced');
+        $title['top-secondary']    = esc_html__('Right bar', 'capsman-enhanced');
+        $title['user-actions']     = esc_html__('User actions', 'capsman-enhanced');
+        $title['new-content']      = esc_html__('New', 'capsman-enhanced');
+        $title['new-content']      = esc_html__('New', 'capsman-enhanced');
+        $title['user-info']        = esc_html__('User Display Name', 'capsman-enhanced');
+        $title['wpseo-menu']       = esc_html__('Yoast SEO', 'capsman-enhanced');
 
         return isset($title[$id]) ? $title[$id] : $id;
     }
@@ -78,10 +78,10 @@ class PP_Capabilities_Admin_Features
      */
     public static function formatHeaderFooter()
     {
-        $elements_item['screen_options'] = ['label'  => __('Screen Options', 'capsman-enhanced'), 'action' => 'ppc_header_footer'];
-        $elements_item['screen_help'] = ['label'  => __('Help', 'capsman-enhanced'), 'action' => 'ppc_header_footer'];
-        $elements_item['footer_thankyou'] = ['label'  => __('Thank you for creating with WordPress', 'capsman-enhanced'), 'action' => 'ppc_header_footer'];
-        $elements_item['footer_upgrade'] = ['label'  => sprintf( __( 'Version %s' ), get_bloginfo('version'), 'capsman-enhanced' ), 'action' => 'ppc_header_footer'];
+        $elements_item['screen_options'] = ['label'  => esc_html__('Screen Options', 'capsman-enhanced'), 'action' => 'ppc_header_footer'];
+        $elements_item['screen_help'] = ['label'  => esc_html__('Help', 'capsman-enhanced'), 'action' => 'ppc_header_footer'];
+        $elements_item['footer_thankyou'] = ['label'  => esc_html__('Thank you for creating with WordPress', 'capsman-enhanced'), 'action' => 'ppc_header_footer'];
+        $elements_item['footer_upgrade'] = ['label'  => sprintf( esc_html__( 'Version %s' ), get_bloginfo('version'), 'capsman-enhanced' ), 'action' => 'ppc_header_footer'];
 
         return $elements_item;
     }
@@ -130,7 +130,7 @@ class PP_Capabilities_Admin_Features
 
         $elements_widget = [];
         //add widget that may not be part of wp_meta_boxes
-        $elements_widget['dashboard_welcome_panel'] = ['label'  => __('Welcome panel', 'capsman-enhanced'), 'context' => 'normal', 'action' => 'ppc_dashboard_widget'];
+        $elements_widget['dashboard_welcome_panel'] = ['label'  => esc_html__('Welcome panel', 'capsman-enhanced'), 'context' => 'normal', 'action' => 'ppc_dashboard_widget'];
         //loop other widgets
         foreach ($widgets as $context => $priority) {
             foreach ($priority as $data) {
@@ -304,7 +304,7 @@ class PP_Capabilities_Admin_Features
             if(count($ppc_header_footer) > 0){
                 self::disableHeaderFooterElement($ppc_header_footer);
             }
-		   }
+        }
     }
 
 	/**

--- a/includes/features/restrict-editor-features.php
+++ b/includes/features/restrict-editor-features.php
@@ -37,38 +37,38 @@ class PP_Capabilities_Post_Features {
     {
         $elements = [];
 
-        $elements[__('Top Tabs', 'capsman-enhanced')] = [
-            '#contextual-help-link-wrap' => ['label' => __('Help', 'capsman-enhanced')],
-            '#screen-options-link-wrap' => ['label' => __('Screen Options', 'capsman-enhanced')],
+        $elements[esc_html__('Top Tabs', 'capsman-enhanced')] = [
+            '#contextual-help-link-wrap' => ['label' => esc_html__('Help', 'capsman-enhanced')],
+            '#screen-options-link-wrap' => ['label' => esc_html__('Screen Options', 'capsman-enhanced')],
         ];
 
-        $elements[__('Editor', 'capsman-enhanced')] = [
-            '.page-title-action' => ['label' => __('Add New', 'capsman-enhanced')],
-            '#title' => ['label' => __('Title', 'capsman-enhanced'),                          'elements' => '#titlediv, #title, #titlewrap'],
-            '#postdivrich' => ['label' => __('Editor', 'capsman-enhanced')],
-            '#pageslugdiv' => ['label' => __('Permalink', 'capsman-enhanced')],
-            '#media_buttons' => ['label' => __('Media Buttons (all)', 'capsman-enhanced'),    'elements' => '#media-buttons, #wp-content-media-buttons'],
-            '#html_editor_button' => ['label' => __('HTML Editor Button', 'capsman-enhanced'),'elements' => '#editor-toolbar #edButtonHTML, #quicktags, #content-html, .wp-switch-editor.switch-html'],
-            '#wp-word-count' => ['label' => __('Word count', 'capsman-enhanced')],
+        $elements[esc_html__('Editor', 'capsman-enhanced')] = [
+            '.page-title-action' => ['label' => esc_html__('Add New', 'capsman-enhanced')],
+            '#title' => ['label' => esc_html__('Title', 'capsman-enhanced'),                          'elements' => '#titlediv, #title, #titlewrap'],
+            '#postdivrich' => ['label' => esc_html__('Editor', 'capsman-enhanced')],
+            '#pageslugdiv' => ['label' => esc_html__('Permalink', 'capsman-enhanced')],
+            '#media_buttons' => ['label' => esc_html__('Media Buttons (all)', 'capsman-enhanced'),    'elements' => '#media-buttons, #wp-content-media-buttons'],
+            '#html_editor_button' => ['label' => esc_html__('HTML Editor Button', 'capsman-enhanced'),'elements' => '#editor-toolbar #edButtonHTML, #quicktags, #content-html, .wp-switch-editor.switch-html'],
+            '#wp-word-count' => ['label' => esc_html__('Word count', 'capsman-enhanced')],
         ];
 
-        $elements[__('Publish Box', 'capsman-enhanced')] = [
-            '#submitdiv' => ['label' => __('Publish Box', 'capsman-enhanced')],
-            '#save-post' => ['label' => __('Save Draft', 'capsman-enhanced')],
-            '#post-preview' => ['label' => __('Preview', 'capsman-enhanced')],
-            '.misc-pub-post-status' => ['label' => __('Publish Status ', 'capsman-enhanced')],
-            '.misc-pub-visibility' => ['label' => __('Publish Visibility', 'capsman-enhanced')],
-            '#passworddiv' => ['label' => __('Password Protect This Post', 'capsman-enhanced')],
-            '#misc-publishing-actions' => ['label' => __('Publish Actions', 'capsman-enhanced')],
-            '.misc-pub-curtime' => ['label' => __('Publish Schedule', 'capsman-enhanced')],
-            '#date' => ['label' => __('Date', 'capsman-enhanced'),                            'elements' => '#date, #datediv, th.column-date, td.date, div.curtime'],
-            '#publish' => ['label' => __('Publish', 'capsman-enhanced')],
+        $elements[esc_html__('Publish Box', 'capsman-enhanced')] = [
+            '#submitdiv' => ['label' => esc_html__('Publish Box', 'capsman-enhanced')],
+            '#save-post' => ['label' => esc_html__('Save Draft', 'capsman-enhanced')],
+            '#post-preview' => ['label' => esc_html__('Preview', 'capsman-enhanced')],
+            '.misc-pub-post-status' => ['label' => esc_html__('Publish Status ', 'capsman-enhanced')],
+            '.misc-pub-visibility' => ['label' => esc_html__('Publish Visibility', 'capsman-enhanced')],
+            '#passworddiv' => ['label' => esc_html__('Password Protect This Post', 'capsman-enhanced')],
+            '#misc-publishing-actions' => ['label' => esc_html__('Publish Actions', 'capsman-enhanced')],
+            '.misc-pub-curtime' => ['label' => esc_html__('Publish Schedule', 'capsman-enhanced')],
+            '#date' => ['label' => esc_html__('Date', 'capsman-enhanced'),                            'elements' => '#date, #datediv, th.column-date, td.date, div.curtime'],
+            '#publish' => ['label' => esc_html__('Publish', 'capsman-enhanced')],
         ];
 
-        $elements[__('Taxonomy Boxes', 'capsman-enhanced')] = [
-            '#category' => ['label' => __('Categories', 'capsman-enhanced'),                  'elements' => '#categories, #categorydiv, #categorydivsb, th.column-categories, td.categories'],
-            '#category-add-toggle' => ['label' => __('Add New Category', 'capsman-enhanced')],
-            '#post_tag' => ['label' => __('Tags', 'capsman-enhanced'),                        'elements' => '#tags, #tagsdiv,#tagsdivsb,#tagsdiv-post_tag, th.column-tags, td.tags'],
+        $elements[esc_html__('Taxonomy Boxes', 'capsman-enhanced')] = [
+            '#category' => ['label' => esc_html__('Categories', 'capsman-enhanced'),                  'elements' => '#categories, #categorydiv, #categorydivsb, th.column-categories, td.categories'],
+            '#category-add-toggle' => ['label' => esc_html__('Add New Category', 'capsman-enhanced')],
+            '#post_tag' => ['label' => esc_html__('Tags', 'capsman-enhanced'),                        'elements' => '#tags, #tagsdiv,#tagsdivsb,#tagsdiv-post_tag, th.column-tags, td.tags'],
         ];
 
         end($elements);
@@ -80,26 +80,26 @@ class PP_Capabilities_Post_Features {
             }
         }
 
-        $elements[__('Page Boxes', 'capsman-enhanced')] = [
-            '#pageparentdiv' => ['label' => __('Page Attributes', 'capsman-enhanced')],
-            '#parent_id' => ['label' => __('Parent', 'capsman-enhanced'),                     'elements' => 'p.parent-id-label-wrapper, #parent_id'],
-            '#page_template' => ['label' => __('Page Template', 'capsman-enhanced')],
-            'p.menu-order-label-wrapper' => ['label' => __('Order', 'capsman-enhanced')],
+        $elements[esc_html__('Page Boxes', 'capsman-enhanced')] = [
+            '#pageparentdiv' => ['label' => esc_html__('Page Attributes', 'capsman-enhanced')],
+            '#parent_id' => ['label' => esc_html__('Parent', 'capsman-enhanced'),                     'elements' => 'p.parent-id-label-wrapper, #parent_id'],
+            '#page_template' => ['label' => esc_html__('Page Template', 'capsman-enhanced')],
+            'p.menu-order-label-wrapper' => ['label' => esc_html__('Order', 'capsman-enhanced')],
         ];
 
-        $elements[__('Other Boxes', 'capsman-enhanced')] = [
-            '#postimagediv' => ['label' => __('Featured Image', 'capsman-enhanced')],
-            '#slug' => ['label' => __('Post Slug', 'capsman-enhanced'),                       'elements' => '#slugdiv,#edit-slug-box'],
-            '#commentstatusdiv' => ['label' => __('Discussion', 'capsman-enhanced')],
+        $elements[esc_html__('Other Boxes', 'capsman-enhanced')] = [
+            '#postimagediv' => ['label' => esc_html__('Featured Image', 'capsman-enhanced')],
+            '#slug' => ['label' => esc_html__('Post Slug', 'capsman-enhanced'),                       'elements' => '#slugdiv,#edit-slug-box'],
+            '#commentstatusdiv' => ['label' => esc_html__('Discussion', 'capsman-enhanced')],
         ];
 
         end($elements);
         $k = key($elements);
 
             /*
-            __('Related, Shortcuts', 'capsman-enhanced') =>          '.side-info',
-            __('Messages', 'capsman-enhanced') =>                    '#notice',
-            __('h2: Advanced Options', 'capsman-enhanced') =>        '#post-body h2',
+            esc_html__('Related, Shortcuts', 'capsman-enhanced') =>          '.side-info',
+            esc_html__('Messages', 'capsman-enhanced') =>                    '#notice',
+            esc_html__('h2: Advanced Options', 'capsman-enhanced') =>        '#post-body h2',
             */
 
         $post_type_supports = [];
@@ -296,34 +296,34 @@ class PP_Capabilities_Post_Features {
     public static function elementsLayout()
     {
         $elements = [
-            __('Top Bar - Left', 'capabilities-pro') => [
-                'add_block' => ['label' => __('Add block', 'capsman-enhanced'), 'elements' => '.edit-post-header-toolbar .edit-post-header-toolbar__inserter-toggle.has-icon'],
-                'modes' =>     ['label' => __('Modes', 'capsman-enhanced'),     'elements' => '.edit-post-header-toolbar .components-dropdown:first-of-type'],
-                'undo' =>      ['label' => __('Undo', 'capsman-enhanced'),      'elements' => '.edit-post-header-toolbar .editor-history__undo'],
-                'redo' =>      ['label' => __('Redo', 'capsman-enhanced'),      'elements' => '.edit-post-header-toolbar .editor-history__redo'],
-                'details' =>   ['label' => __('Details', 'capsman-enhanced'),   'elements' => '.edit-post-header__toolbar .table-of-contents'],
-                'outline' =>   ['label' => __('Outline', 'capsman-enhanced'),   'elements' => '.edit-post-header__toolbar .edit-post-header-toolbar__list-view-toggle'],
+            esc_html__('Top Bar - Left', 'capabilities-pro') => [
+                'add_block' => ['label' => esc_html__('Add block', 'capsman-enhanced'), 'elements' => '.edit-post-header-toolbar .edit-post-header-toolbar__inserter-toggle.has-icon'],
+                'modes' =>     ['label' => esc_html__('Modes', 'capsman-enhanced'),     'elements' => '.edit-post-header-toolbar .components-dropdown:first-of-type'],
+                'undo' =>      ['label' => esc_html__('Undo', 'capsman-enhanced'),      'elements' => '.edit-post-header-toolbar .editor-history__undo'],
+                'redo' =>      ['label' => esc_html__('Redo', 'capsman-enhanced'),      'elements' => '.edit-post-header-toolbar .editor-history__redo'],
+                'details' =>   ['label' => esc_html__('Details', 'capsman-enhanced'),   'elements' => '.edit-post-header__toolbar .table-of-contents'],
+                'outline' =>   ['label' => esc_html__('Outline', 'capsman-enhanced'),   'elements' => '.edit-post-header__toolbar .edit-post-header-toolbar__list-view-toggle'],
             ],
 
-            __('Top Bar - Right', 'capabilities-pro') => [
-                'save_draft' =>       ['label' => __('Save Draft', 'capsman-enhanced'),       'elements' => '.edit-post-header__settings .components-button.editor-post-save-draft'],
-                'switch_to_draft' =>  ['label' => __('Switch to draft', 'capsman-enhanced'),  'elements' => '.edit-post-header__settings .components-button.editor-post-switch-to-draft'],
-                'preview' =>          ['label' => __('Preview', 'capsman-enhanced'),          'elements' => '.edit-post-header__settings .block-editor-post-preview__dropdown'],
-                'publish' =>          ['label' => __('Publish / Update', 'capsman-enhanced'), 'elements' => '.edit-post-header__settings .editor-post-publish-button__button'],
-                'settings' =>         ['label' => __('Settings', 'capsman-enhanced'),         'elements' => '.edit-post-header__settings .interface-pinned-items button'],
-                'options' =>          ['label' => __('Options', 'capsman-enhanced'),          'elements' => '.edit-post-header__settings .edit-post-more-menu .components-button'],
+            esc_html__('Top Bar - Right', 'capabilities-pro') => [
+                'save_draft' =>       ['label' => esc_html__('Save Draft', 'capsman-enhanced'),       'elements' => '.edit-post-header__settings .components-button.editor-post-save-draft'],
+                'switch_to_draft' =>  ['label' => esc_html__('Switch to draft', 'capsman-enhanced'),  'elements' => '.edit-post-header__settings .components-button.editor-post-switch-to-draft'],
+                'preview' =>          ['label' => esc_html__('Preview', 'capsman-enhanced'),          'elements' => '.edit-post-header__settings .block-editor-post-preview__dropdown'],
+                'publish' =>          ['label' => esc_html__('Publish / Update', 'capsman-enhanced'), 'elements' => '.edit-post-header__settings .editor-post-publish-button__button'],
+                'settings' =>         ['label' => esc_html__('Settings', 'capsman-enhanced'),         'elements' => '.edit-post-header__settings .interface-pinned-items button'],
+                'options' =>          ['label' => esc_html__('Options', 'capsman-enhanced'),          'elements' => '.edit-post-header__settings .edit-post-more-menu .components-button'],
             ],
 
-            __('Body', 'capabilities-pro') => [
-                'edit_title' =>   ['label' => __('Edit title', 'capsman-enhanced'), 'elements' => '.wp-block.editor-post-title__block'],
-                'content' =>      ['label' => __('Content', 'capsman-enhanced'),    'elements' => '.block-editor-block-list__layout'],
+            esc_html__('Body', 'capabilities-pro') => [
+                'edit_title' =>   ['label' => esc_html__('Edit title', 'capsman-enhanced'), 'elements' => '.wp-block.editor-post-title__block'],
+                'content' =>      ['label' => esc_html__('Content', 'capsman-enhanced'),    'elements' => '.block-editor-block-list__layout'],
             ],
 
-            __('Document Panel', 'capabilities-pro') => [
-                'status_visibility' => ['label' => __('Status & visibility', 'capsman-enhanced'),   'elements' => 'post-status'],
-                'permalink' =>         ['label' => __('Permalink', 'capsman-enhanced'),             'elements' => 'post-link'],
-                'categories' =>        ['label' => __('Categories', 'capsman-enhanced'),            'elements' => 'taxonomy-panel-category'],
-                'tags' =>              ['label' => __('Tags', 'capsman-enhanced'),                  'elements' => 'taxonomy-panel-post_tag'],
+            esc_html__('Document Panel', 'capabilities-pro') => [
+                'status_visibility' => ['label' => esc_html__('Status & visibility', 'capsman-enhanced'),   'elements' => 'post-status'],
+                'permalink' =>         ['label' => esc_html__('Permalink', 'capsman-enhanced'),             'elements' => 'post-link'],
+                'categories' =>        ['label' => esc_html__('Categories', 'capsman-enhanced'),            'elements' => 'taxonomy-panel-category'],
+                'tags' =>              ['label' => esc_html__('Tags', 'capsman-enhanced'),                  'elements' => 'taxonomy-panel-post_tag'],
             ]
         ];
         
@@ -337,18 +337,18 @@ class PP_Capabilities_Post_Features {
         }
 
         $elements[$k] = array_merge($elements[$k], [
-            'featured_image'  => ['label' => __('Featured image', 'capsman-enhanced'),  'elements'  => 'featured-image'],
-            'excerpt'         => ['label' => __('Excerpt', 'capsman-enhanced'),         'elements'  => 'post-excerpt'],
-            'discussion'      => ['label' => __('Discussion', 'capsman-enhanced'),      'elements'  => 'discussion-panel'],
-            'post_attributes' => ['label' => __('Post Attributes', 'capsman-enhanced'), 'elements'  => 'page-attributes'],
+            'featured_image'  => ['label' => esc_html__('Featured image', 'capsman-enhanced'),  'elements'  => 'featured-image'],
+            'excerpt'         => ['label' => esc_html__('Excerpt', 'capsman-enhanced'),         'elements'  => 'post-excerpt'],
+            'discussion'      => ['label' => esc_html__('Discussion', 'capsman-enhanced'),      'elements'  => 'discussion-panel'],
+            'post_attributes' => ['label' => esc_html__('Post Attributes', 'capsman-enhanced'), 'elements'  => 'page-attributes'],
         ]);
 
-        $elements[__('Block Panel', 'capabilities-pro')] = [
-            'block_panel' =>   ['label' => __('Block Panel', 'capsman-enhanced'),       'elements' => '.block-editor-block-inspector'],
-            'paragraph' =>     ['label' => __('Paragraph', 'capsman-enhanced'),         'elements' => '.block-editor-block-card'],
-            'typography' =>    ['label' => __('Typography', 'capsman-enhanced'),        'elements' => '.block-editor-block-inspector .components-panel__body:first-of-type'],
-            'color' =>         ['label' =>  __('Color settings', 'capsman-enhanced'),   'elements' => '.block-editor-panel-color-gradient-settings'],
-            'text_settings' => ['label' => __('Text settings', 'capsman-enhanced'),     'elements' => '.block-editor-panel-color-gradient-settings + .components-panel__body'],
+        $elements[esc_html__('Block Panel', 'capabilities-pro')] = [
+            'block_panel' =>   ['label' => esc_html__('Block Panel', 'capsman-enhanced'),       'elements' => '.block-editor-block-inspector'],
+            'paragraph' =>     ['label' => esc_html__('Paragraph', 'capsman-enhanced'),         'elements' => '.block-editor-block-card'],
+            'typography' =>    ['label' => esc_html__('Typography', 'capsman-enhanced'),        'elements' => '.block-editor-block-inspector .components-panel__body:first-of-type'],
+            'color' =>         ['label' =>  esc_html__('Color settings', 'capsman-enhanced'),   'elements' => '.block-editor-panel-color-gradient-settings'],
+            'text_settings' => ['label' => esc_html__('Text settings', 'capsman-enhanced'),     'elements' => '.block-editor-panel-color-gradient-settings + .components-panel__body'],
         ];
 
         return apply_filters('pp_capabilities_post_feature_elements', $elements);

--- a/includes/filters-woocommerce.php
+++ b/includes/filters-woocommerce.php
@@ -29,8 +29,8 @@ class CME_WooCommerce {
 				$submenu[$key] = array();
 			}
 			
-			$submenu[$key][5] = array( 0 => sprintf( __( 'All %s' ), $type_obj->labels->name ), 1 => $type_obj->cap->edit_posts, 2 => 'edit.php?post_type=shop_order' );
-			$submenu[$key][10] = array( __('Add New'), 1 => $type_obj->cap->create_posts, 2 => 'post-new.php?post_type=shop_order' );
+			$submenu[$key][5] = array( 0 => sprintf( esc_html__( 'All %s' ), $type_obj->labels->name ), 1 => $type_obj->cap->edit_posts, 2 => 'edit.php?post_type=shop_order' );
+			$submenu[$key][10] = array( esc_html__('Add New'), 1 => $type_obj->cap->create_posts, 2 => 'post-new.php?post_type=shop_order' );
 		}
 	}
 }

--- a/includes/filters.php
+++ b/includes/filters.php
@@ -260,7 +260,7 @@ function _cme_fltPluginActionLinks($links, $file)
 {
 	if ($file == plugin_basename(CME_FILE)) {
 		if (!is_network_admin()) {
-			$links[] = "<a href='" . admin_url("admin.php?page=pp-capabilities") . "'>" . __('Edit Roles', 'capsman-enhanced') . "</a>";
+			$links[] = "<a href='" . admin_url("admin.php?page=pp-capabilities") . "'>" . esc_html__('Edit Roles', 'capsman-enhanced') . "</a>";
 		}
 	}
 

--- a/includes/manager.php
+++ b/includes/manager.php
@@ -430,7 +430,7 @@ class CapabilityManager
 	{
 		if ((!is_multisite() || !is_super_admin()) && !current_user_can('administrator') && !current_user_can('manage_capabilities')) {
             // TODO: Implement exceptions.
-		    wp_die('<strong>' .__('You do not have permission to manage roles.', 'capsman-enhanced') . '</strong>');
+		    wp_die('<strong>' . esc_html__('You do not have permission to manage roles.', 'capsman-enhanced') . '</strong>');
 		}
 
         require_once (dirname(CME_FILE) . '/includes/roles/roles-functions.php');
@@ -453,7 +453,7 @@ class CapabilityManager
 	public function ManageEditorFeatures() {
 		if ((!is_multisite() || !is_super_admin()) && !current_user_can('administrator') && !current_user_can('manage_capabilities')) {
             // TODO: Implement exceptions.
-		    wp_die('<strong>' .__('You do not have permission to manage editor features.', 'capabilities-pro') . '</strong>');
+		    wp_die('<strong>' . esc_html__('You do not have permission to manage editor features.', 'capabilities-pro') . '</strong>');
 		}
 
 		$this->generateNames();
@@ -475,7 +475,7 @@ class CapabilityManager
 
 		if ('POST' == $_SERVER['REQUEST_METHOD'] && isset($_POST['ppc-editor-features-role'])) {
 			if (!check_admin_referer('pp-capabilities-editor-features')) {
-				wp_die('<strong>' .__('You do not have permission to manage editor features.', 'capabilities-pro') . '</strong>');
+				wp_die('<strong>' . esc_html__('You do not have permission to manage editor features.', 'capabilities-pro') . '</strong>');
 			} else {
 				$this->set_current_role(sanitize_key($_POST['ppc-editor-features-role']));
 
@@ -513,7 +513,7 @@ class CapabilityManager
 	public function ManageAdminFeatures() {
 		if ((!is_multisite() || !is_super_admin()) && !current_user_can('administrator') && !current_user_can('manage_capabilities')) {
             // TODO: Implement exceptions.
-		    wp_die('<strong>' .__('You do not have permission to manage admin features.', 'capabilities-pro') . '</strong>');
+		    wp_die('<strong>' . esc_html__('You do not have permission to manage admin features.', 'capabilities-pro') . '</strong>');
 		}
 
 		$this->generateNames();
@@ -535,7 +535,7 @@ class CapabilityManager
 
 		if ('POST' == $_SERVER['REQUEST_METHOD'] && isset($_POST['ppc-admin-features-role'])) {
 			if (!check_admin_referer('pp-capabilities-admin-features')) {
-				wp_die('<strong>' .__('You do not have permission to manage admin features.', 'capabilities-pro') . '</strong>');
+				wp_die('<strong>' . esc_html__('You do not have permission to manage admin features.', 'capabilities-pro') . '</strong>');
 			} else {
 				$features_role = sanitize_key($_POST['ppc-admin-features-role']);
 				
@@ -656,7 +656,7 @@ class CapabilityManager
 			
 			if ((!is_multisite() || !is_super_admin()) && !current_user_can('administrator') && !current_user_can('manage_capabilities')) {
 				// TODO: Implement exceptions.
-				wp_die('<strong>' .__('You do not have permission to manage capabilities.', 'capsman-enhanced') . '</strong>');
+				wp_die('<strong>' . esc_html__('You do not have permission to manage capabilities.', 'capsman-enhanced') . '</strong>');
 			}
 
 			if ( ! empty($_REQUEST['current']) ) { // don't process role update unless form variable is received
@@ -690,7 +690,7 @@ class CapabilityManager
 			
 			if ((!is_multisite() || !is_super_admin()) && !current_user_can('administrator') && !current_user_can('manage_capabilities')) {
 				// TODO: Implement exceptions.
-				wp_die('<strong>' .__('You do not have permission to manage capabilities.', 'capsman-enhanced') . '</strong>');
+				wp_die('<strong>' . esc_html__('You do not have permission to manage capabilities.', 'capsman-enhanced') . '</strong>');
 			}
 
 			if ( ! empty($_REQUEST['current']) ) { // don't process role update unless form variable is received
@@ -708,7 +708,7 @@ class CapabilityManager
 	function generalManager () {
 		if ((!is_multisite() || !is_super_admin()) && !current_user_can('administrator') && !current_user_can('manage_capabilities')) {
             // TODO: Implement exceptions.
-		    wp_die('<strong>' .__('You do not have permission to manage capabilities.', 'capsman-enhanced') . '</strong>');
+		    wp_die('<strong>' . esc_html__('You do not have permission to manage capabilities.', 'capsman-enhanced') . '</strong>');
 		}
 
 		if ( 'POST' == $_SERVER['REQUEST_METHOD'] ) {
@@ -740,7 +740,7 @@ class CapabilityManager
 				$role = sanitize_key($_REQUEST['role']);
 
 				if (!pp_capabilities_is_editable_role($role)) {
-					wp_die(__('The selected role is not editable.', 'capsman-enhanced'));
+					wp_die(esc_html__('The selected role is not editable.', 'capsman-enhanced'));
 				}
 
 				$this->set_current_role($role);
@@ -887,7 +887,7 @@ class CapabilityManager
 	{
 		if ((!is_multisite() || !is_super_admin()) && !current_user_can('administrator') && !current_user_can('restore_roles')) {
 		    // TODO: Implement exceptions.
-			wp_die('<strong>' .__('You do not have permission to restore roles.', 'capsman-enhanced') . '</strong>');
+			wp_die('<strong>' . esc_html__('You do not have permission to restore roles.', 'capsman-enhanced') . '</strong>');
 		}
 
 		if ( 'POST' == $_SERVER['REQUEST_METHOD'] ) {
@@ -917,7 +917,7 @@ function cme_publishpressFooter() {
 	<div class="pp-rating">
 	<a href="https://wordpress.org/support/plugin/capability-manager-enhanced/reviews/#new-post" target="_blank" rel="noopener noreferrer">
 	<?php printf(
-		__('If you like %s, please leave us a %s rating. Thank you!', 'capsman-enhanced'),
+		esc_html__('If you like %s, please leave us a %s rating. Thank you!', 'capsman-enhanced'),
 		'<strong>PublishPress Capabilities</strong>',
 		'<span class="dashicons dashicons-star-filled"></span><span class="dashicons dashicons-star-filled"></span><span class="dashicons dashicons-star-filled"></span><span class="dashicons dashicons-star-filled"></span><span class="dashicons dashicons-star-filled"></span>'
 		);
@@ -928,11 +928,11 @@ function cme_publishpressFooter() {
 	<hr>
 	<nav>
 	<ul>
-	<li><a href="https://publishpress.com/capability-manager/" target="_blank" rel="noopener noreferrer" title="<?php _e('About PublishPress Capabilities', 'capsman-enhanced');?>"><?php _e('About', 'capsman-enhanced');?>
+	<li><a href="https://publishpress.com/capability-manager/" target="_blank" rel="noopener noreferrer" title="<?php esc_attr_e('About PublishPress Capabilities', 'capsman-enhanced');?>"><?php esc_html_e('About', 'capsman-enhanced');?>
 	</a></li>
-	<li><a href="https://publishpress.com/knowledge-base/how-to-use-capability-manager/" target="_blank" rel="noopener noreferrer" title="<?php _e('Capabilites Documentation', 'capsman-enhanced');?>"><?php _e('Documentation', 'capsman-enhanced');?>
+	<li><a href="https://publishpress.com/knowledge-base/how-to-use-capability-manager/" target="_blank" rel="noopener noreferrer" title="<?php esc_attr_e('Capabilites Documentation', 'capsman-enhanced');?>"><?php esc_html_e('Documentation', 'capsman-enhanced');?>
 	</a></li>
-	<li><a href="https://publishpress.com/contact" target="_blank" rel="noopener noreferrer" title="<?php _e('Contact the PublishPress team', 'capsman-enhanced');?>"><?php _e('Contact', 'capsman-enhanced');?>
+	<li><a href="https://publishpress.com/contact" target="_blank" rel="noopener noreferrer" title="<?php esc_attr_e('Contact the PublishPress team', 'capsman-enhanced');?>"><?php esc_html_e('Contact', 'capsman-enhanced');?>
 	</a></li>
 	<li><a href="https://twitter.com/publishpresscom" target="_blank" rel="noopener noreferrer"><span class="dashicons dashicons-twitter"></span>
 	</a></li>

--- a/includes/manager.php
+++ b/includes/manager.php
@@ -722,7 +722,7 @@ class CapabilityManager
 			}
 		} else {
 			if (!empty($_REQUEST['added'])) {
-				ak_admin_notify(__('New capability added to role.'));
+				ak_admin_notify(__('New capability added to role.', 'capsman-enhanced'));
 			}
 		}
 

--- a/includes/pp-ui.php
+++ b/includes/pp-ui.php
@@ -47,16 +47,16 @@ class Capsman_PP_UI {
 				echo '<li>';
 				if ( defined( 'PPCE_VERSION' ) || ! defined( 'PRESSPERMIT_ACTIVE' ) ) {
 					if ( pp_capabilities_get_permissions_option( 'advanced_options' ) )
-						$parenthetical = ' (' . sprintf( __( 'see %1$sRole Usage%2$s: "Pattern Roles"', 'capsman-enhanced' ), "<a href='" . admin_url("admin.php?page={$pp_prefix}-role-usage") . "'>", '</a>' ) . ')';
+						$parenthetical = ' (' . sprintf( esc_html__( 'see %1$sRole Usage%2$s: "Pattern Roles"', 'capsman-enhanced' ), "<a href='" . admin_url("admin.php?page={$pp_prefix}-role-usage") . "'>", '</a>' ) . ')';
 					else
-						$parenthetical = ' (' . sprintf( __( 'activate %1$sAdvanced settings%2$s, see Role Usage', 'capsman-enhanced' ), "<a href='" . admin_url("admin.php?page={$pp_prefix}-settings&pp_tab=advanced") . "'>", '</a>' ). ')';
+						$parenthetical = ' (' . sprintf( esc_html__( 'activate %1$sAdvanced settings%2$s, see Role Usage', 'capsman-enhanced' ), "<a href='" . admin_url("admin.php?page={$pp_prefix}-settings&pp_tab=advanced") . "'>", '</a>' ). ')';
 				} else
 					$parenthetical = '';
 
 				if ( defined( 'PRESSPERMIT_ACTIVE' ) )
-					printf( __( '"Posts" capabilities selected here also define type-specific role assignment for Permission Groups%s.', 'capsman-enhanced' ), $parenthetical ) ;
+					printf( esc_html__( '"Posts" capabilities selected here also define type-specific role assignment for Permission Groups%s.', 'capsman-enhanced' ), $parenthetical ) ;
 				else
-					printf( __( '"Posts" capabilities selected here also define type-specific role assignment for Permit Groups%s.', 'capsman-enhanced' ), $parenthetical ) ;
+					printf( esc_html__( '"Posts" capabilities selected here also define type-specific role assignment for Permit Groups%s.', 'capsman-enhanced' ), $parenthetical ) ;
 
 				echo '</li>';
 			}
@@ -64,12 +64,12 @@ class Capsman_PP_UI {
 			$status_hint = '';
 			if ( defined( 'PRESSPERMIT_ACTIVE' ) )
 				if ( defined( 'PPS_VERSION' ) )
-					$status_hint = sprintf( __( 'Capabilities for custom statuses can be manually added here. (See %sPermissions > Post Statuses%s for applicable names). %sSupplemental status-specific roles%s are usually more convenient, though.', 'capsman-enhanced' ), "<a href='" . admin_url("admin.php?page={$pp_prefix}-statuses&show_caps=1") . "'>", '</a>', "<a href='" . admin_url("admin.php?page={$pp_prefix}-groups") . "'>", '</a>' ) ;
+					$status_hint = sprintf( esc_html__( 'Capabilities for custom statuses can be manually added here. (See %sPermissions > Post Statuses%s for applicable names). %sSupplemental status-specific roles%s are usually more convenient, though.', 'capsman-enhanced' ), "<a href='" . admin_url("admin.php?page={$pp_prefix}-statuses&show_caps=1") . "'>", '</a>', "<a href='" . admin_url("admin.php?page={$pp_prefix}-groups") . "'>", '</a>' ) ;
 				elseif ( pp_capabilities_get_permissions_option( 'display_extension_hints' ) )
-					$status_hint = sprintf( __( 'Capabilities for custom statuses can be manually added here. Or activate the PP Custom Post Statuses extension to assign status-specific supplemental roles.', 'capsman-enhanced' ), "<a href='" . admin_url("admin.php?page={$pp_prefix}-role-usage") . "'>", '</a>' ) ;
+					$status_hint = sprintf( esc_html__( 'Capabilities for custom statuses can be manually added here. Or activate the PP Custom Post Statuses extension to assign status-specific supplemental roles.', 'capsman-enhanced' ), "<a href='" . admin_url("admin.php?page={$pp_prefix}-role-usage") . "'>", '</a>' ) ;
 			
 			elseif ( defined( 'PP_VERSION' ) )
-				$status_hint = sprintf( __( 'Capabilities for custom statuses can be manually added to a role here (see Conditions > Status > Capability Mapping for applicable names). However, it is usually more convenient to use Permit Groups to assign a supplemental status-specific role.', 'capsman-enhanced' ), "<a href='" . admin_url("admin.php?page={$pp_prefix}-role-usage") . "'>", '</a>' ) ;
+				$status_hint = sprintf( esc_html__( 'Capabilities for custom statuses can be manually added to a role here (see Conditions > Status > Capability Mapping for applicable names). However, it is usually more convenient to use Permit Groups to assign a supplemental status-specific role.', 'capsman-enhanced' ), "<a href='" . admin_url("admin.php?page={$pp_prefix}-role-usage") . "'>", '</a>' ) ;
 			
 			if ( $status_hint )
 				echo "<li>$status_hint</li>";
@@ -82,10 +82,10 @@ class Capsman_PP_UI {
 	function pp_types_ui( $defined_types ) {
 		?>
 		<dl>
-			<dt><?php _e('Type-Specific Capabilities', 'capsman-enhanced'); ?></dt>
+			<dt><?php esc_html_e('Type-Specific Capabilities', 'capsman-enhanced'); ?></dt>
 			<dd style="text-align:center;">
 				<?php
-				$caption = __( 'Ensure permissions can be controlled separately from other post types.', 'capsman-enhanced' );
+				$caption = esc_html__( 'Ensure permissions can be controlled separately from other post types.', 'capsman-enhanced' );
 				echo "<p class='cme-hint'>$caption</p>";
 				
 				if ( defined( 'PRESSPERMIT_ACTIVE' ) && pp_capabilities_get_permissions_option( 'display_hints' ) ) :?>
@@ -117,6 +117,8 @@ class Capsman_PP_UI {
 					if ( in_array( $key, $unfiltered ) )
 						continue;
 						
+					$key = sanitize_key($key);
+
 					$id = "$option_basename-" . $key;
 					?>
 					<div style="text-align:left">
@@ -128,7 +130,7 @@ class Capsman_PP_UI {
 						<div class="agp-vspaced_input">
 						<label for="<?php echo($id);?>" title="<?php echo($key);?>">
 						<input name="<?php echo("{$option_basename}-options[]");?>" type="hidden" value="<?php echo($key)?>" />
-						<input name="<?php echo($id);?>" type="checkbox" id="<?php echo($id);?>" autocomplete="off" value="1" <?php checked('1', ! empty($enabled[$key]) );?> /> <?php echo($type_obj->label);?>
+						<input name="<?php echo($id);?>" type="checkbox" id="<?php echo($id);?>" autocomplete="off" value="1" <?php checked('1', ! empty($enabled[$key]) );?> /> <?php echo(esc_html($type_obj->label));?>
 						
 						<?php 
 						echo ('</label></div>');
@@ -148,7 +150,7 @@ class Capsman_PP_UI {
 				
 					<div style="margin-top:10px;margin-bottom:10px">
 					<label for="pp_define_create_posts_cap">
-					<input name="pp_define_create_posts_cap" type="checkbox" id="pp_define_create_posts_cap" autocomplete="off" value="1" <?php checked('1', $define_create_posts_cap );?> title="<?php esc_attr( _e( 'Make selected post types require a different capability to add new posts.', 'capsman-enhanced') );?>" /> <?php _e('Use create_posts capability');?>
+					<input name="pp_define_create_posts_cap" type="checkbox" id="pp_define_create_posts_cap" autocomplete="off" value="1" <?php checked('1', $define_create_posts_cap );?> title="<?php esc_attr_e( 'Make selected post types require a different capability to add new posts.', 'capsman-enhanced');?>" /> <?php esc_html_e('Use create_posts capability');?>
 					</label>
 					</div>
 				
@@ -156,7 +158,7 @@ class Capsman_PP_UI {
 				do_action('pp-capabilities-type-specific-ui');
 				?>
 
-				<input type="submit" name="update_filtered_types" value="<?php _e('Update', 'capsman-enhanced') ?>" class="button" />
+				<input type="submit" name="update_filtered_types" value="<?php esc_html_e('Update', 'capsman-enhanced') ?>" class="button" />
 			</dd>
 		</dl>
 		<?php
@@ -166,10 +168,10 @@ class Capsman_PP_UI {
 	function pp_taxonomies_ui( $defined_taxonomies ) {
 		?>
 		<dl>
-			<dt><?php _e('Taxonomy-Specific Capabilities', 'capsman-enhanced'); ?></dt>
+			<dt><?php esc_html_e('Taxonomy-Specific Capabilities', 'capsman-enhanced'); ?></dt>
 			<dd style="text-align:center;">
 				<?php
-				$caption = __( 'Ensure permissions can be controlled separately from other taxonomies.', 'capsman-enhanced' );
+				$caption = esc_html__( 'Ensure permissions can be controlled separately from other taxonomies.', 'capsman-enhanced' );
 				echo "<p class='cme-hint'>$caption</p>";
 				
 				echo "<table style='width:100%'><tr>";
@@ -193,6 +195,8 @@ class Capsman_PP_UI {
 					if ( in_array( $taxonomy, $unfiltered ) )
 						continue;
 					
+					$taxonomy = sanitize_key($taxonomy);
+
 					$id = "$option_basename-" . $taxonomy;
 					?>
 					<div style="text-align:left">
@@ -204,7 +208,7 @@ class Capsman_PP_UI {
 						<div class="agp-vspaced_input">
 						<label for="<?php echo($id);?>" title="<?php echo($taxonomy);?>">
 						<input name="<?php echo("{$option_basename}-options[]");?>" type="hidden" value="<?php echo($taxonomy)?>" />
-						<input name="<?php echo($id);?>" type="checkbox" autocomplete="off" id="<?php echo($id);?>" value="1" <?php checked('1', ! empty($enabled[$taxonomy]) );?> /> <?php echo($type_obj->label);?>
+						<input name="<?php echo($id);?>" type="checkbox" autocomplete="off" id="<?php echo($id);?>" value="1" <?php checked('1', ! empty($enabled[$taxonomy]) );?> /> <?php echo(esc_html($type_obj->label));?>
 						
 						<?php 
 						echo ('</label></div>');
@@ -219,15 +223,15 @@ class Capsman_PP_UI {
 				</tr>
 				</table>
 				
-				<input type="submit" name="update_filtered_taxonomies" value="<?php _e('Update', 'capsman-enhanced') ?>" class="button" />
+				<input type="submit" name="update_filtered_taxonomies" value="<?php esc_html_e('Update', 'capsman-enhanced') ?>" class="button" />
 			</dd>
 		</dl>
 		
 		<dl>
-			<dt><?php _e('Detailed Taxonomy Capabilities', 'capsman-enhanced'); ?></dt>
+			<dt><?php esc_html_e('Detailed Taxonomy Capabilities', 'capsman-enhanced'); ?></dt>
 			<dd style="text-align:center;">
 				<?php
-				$caption = __( 'Enforce Edit, Delete and Assign capabilities separately from Management capability.', 'capsman-enhanced' );
+				$caption = esc_html__( 'Enforce Edit, Delete and Assign capabilities separately from Management capability.', 'capsman-enhanced' );
 				echo "<p class='cme-hint'>$caption</p>";
 				
 				echo "<table style='width:100%'><tr>";
@@ -249,6 +253,8 @@ class Capsman_PP_UI {
 					if ( in_array( $taxonomy, $unfiltered ) )
 						continue;
 					
+					$taxonomy = sanitize_key($taxonomy);
+
 					$id = "$option_basename-" . $taxonomy;
 					?>
 					<div style="text-align:left">
@@ -260,7 +266,7 @@ class Capsman_PP_UI {
 						<div class="agp-vspaced_input">
 						<label for="<?php echo($id);?>" title="<?php echo($taxonomy);?>">
 						<input name="<?php echo("{$option_basename}-options[]");?>" type="hidden" value="<?php echo($taxonomy)?>" />
-						<input name="<?php echo($id);?>" type="checkbox" autocomplete="off" id="<?php echo($id);?>" value="1" <?php checked('1', ! empty($enabled[$taxonomy]) );?> /> <?php echo($type_obj->label);?>
+						<input name="<?php echo($id);?>" type="checkbox" autocomplete="off" id="<?php echo($id);?>" value="1" <?php checked('1', ! empty($enabled[$taxonomy]) );?> /> <?php echo(esc_html($type_obj->label));?>
 						
 						<?php 
 						echo ('</label></div>');
@@ -275,7 +281,7 @@ class Capsman_PP_UI {
 				</tr>
 				</table>
 				
-				<input type="submit" name="update_detailed_taxonomies" value="<?php _e('Update', 'capsman-enhanced') ?>" class="button" />
+				<input type="submit" name="update_detailed_taxonomies" value="<?php esc_html_e('Update', 'capsman-enhanced') ?>" class="button" />
 			</dd>
 		</dl>
 		<?php

--- a/includes/roles/class/class-pp-roles-actions.php
+++ b/includes/roles/class/class-pp-roles-actions.php
@@ -103,7 +103,7 @@ class Pp_Roles_Actions
         }
 
         if ($this->is_ajax()) {
-            //$format = '<div class="notice notice-%s is-dismissible"><p>%s</p><button type="button" class="notice-dismiss"><span class="screen-reader-text">' . __('Dismiss this notice.', 'capsman-enhanced') . '</span></button></div>';
+            //$format = '<div class="notice notice-%s is-dismissible"><p>%s</p><button type="button" class="notice-dismiss"><span class="screen-reader-text">' . esc_html__('Dismiss this notice.', 'capsman-enhanced') . '</span></button></div>';
             $format = '<div class="notice notice-%s is-dismissible"><p>%s</p></div>';
             wp_send_json_error(sprintf($format, $type, $message));
             exit;
@@ -140,8 +140,7 @@ class Pp_Roles_Actions
     {
 
         if (!current_user_can($this->capability)) {
-            $out = __('You do not have sufficient permissions to perform this action.', 'capsman-enhanced');
-            $this->notify($out);
+            $this->notify(__('You do not have sufficient permissions to perform this action.', 'capsman-enhanced'));
         }
     }
 
@@ -156,8 +155,7 @@ class Pp_Roles_Actions
 
         $checked = isset($_REQUEST[$query_arg]) && wp_verify_nonce($_REQUEST[$query_arg], $action);
         if (!$checked) {
-            $out = __('Your link has expired, refresh the page and try again.', 'capsman-enhanced');
-            $this->notify($out);
+            $this->notify(__('Your link has expired, refresh the page and try again.', 'capsman-enhanced'));
         }
     }
 
@@ -177,8 +175,7 @@ class Pp_Roles_Actions
         $this->check_nonce('add-role');
 
         if (empty($_REQUEST['name'])) {
-            $out = __('Missing parameters, refresh the page and try again.', 'capsman-enhanced');
-            $this->notify($out);
+            $this->notify(__('Missing parameters, refresh the page and try again.', 'capsman-enhanced'));
         }
 
         /**
@@ -192,7 +189,10 @@ class Pp_Roles_Actions
          * Check for invalid name entry
          */
         if (!empty($role['error']) && ('invalid_name' == $role['error'])) {
-            $out = __(sprintf('Invalid role name entry: %s', "<strong>" . esc_attr($role['name']) . "</strong>"), 'capsman-enhanced');
+            $out = sprintf(
+                __('Invalid role name entry: %s', 'capsman-enhanced'), 
+                "<strong>" . esc_attr($role['name']) . "</strong>"
+            );
             $this->notify($out);
         }
 
@@ -201,7 +201,11 @@ class Pp_Roles_Actions
          */
         if (!empty($role['error']) && ('role_exists' == $role['error'])) {
             //this role already exist
-            $out = __(sprintf('The role "%s" already exists. Please choose a different name.', "<strong>" . esc_attr($role['name']) . "</strong>"), 'capsman-enhanced');
+            $out = sprintf(
+                __('The role "%s" already exists. Please choose a different name.', 'capsman-enhanced'),
+                "<strong>" . esc_attr($role['name']) . "</strong>"
+            );
+
             $this->notify($out);
         }
 
@@ -211,8 +215,7 @@ class Pp_Roles_Actions
         $result = add_role($role['name'], $role['display'], []);
 
         if (!$result instanceof WP_Role) {
-            $out = __('Something went wrong, the system wasn\'t able to create the role, refresh the page and try again.', 'capsman-enhanced');
-            if ($this->notify($out)) {
+            if ($this->notify(__('Something went wrong, the system wasn\'t able to create the role, refresh the page and try again.', 'capsman-enhanced'))) {
                 return;
             }
         }
@@ -242,7 +245,11 @@ class Pp_Roles_Actions
             /**
              * Notify user and redirect
              */
-            $out = __(sprintf('The new role %s was created successfully.', '<strong>' . $role . '</strong>'), 'capsman-enhanced');
+            $out = sprintf(
+                __('The new role %s was created successfully.', 'capsman-enhanced'),
+                '<strong>' . $role . '</strong>'
+            );
+            
             $this->notify($out, 'success');
         }
     }
@@ -259,7 +266,7 @@ class Pp_Roles_Actions
         }
 
         if (empty($role)) {
-            $role = (isset($_REQUEST['role'])) ? sanitize_key($_REQUEST['role']) : '';
+            $role = (isset($_REQUEST['role'])) ? array_map('sanitize_key', (array) ($_REQUEST['role'])) : '';
         }
 
         /**
@@ -295,15 +302,19 @@ class Pp_Roles_Actions
          * If no roles provided return
          */
         if (empty($roles)) {
-            $out = __('Missing parameters, refresh the page and try again.', 'capsman-enhanced');
-            $this->notify($out);
+            $this->notify(__('Missing parameters, refresh the page and try again.', 'capsman-enhanced'));
         }
 
         $default = get_option('default_role');
         
 		if ( $default == $role ) {
             //ak_admin_error(sprintf(__('Cannot delete default role. You <a href="%s">have to change it first</a>.', 'capsman-enhanced'), 'options-general.php'));
-            $this->notify(__('Cannot delete default role. You <a href="%s">have to change it first</a>.', 'capsman-enhanced'), 'options-general.php');
+            $this->notify(
+                sprintf(
+                    __('Cannot delete default role. You <a href="%s">have to change it first</a>.', 'capsman-enhanced'), 
+                    'options-general.php'
+                )
+            );
 			return;
 		}
 
@@ -319,8 +330,7 @@ class Pp_Roles_Actions
             }
 
             if (empty($roles)) {
-                $out = __('Deleting a system role is not allowed.', 'capsman-enhanced');
-                $this->notify($out);
+                $this->notify(__('Deleting a system role is not allowed.', 'capsman-enhanced'));
             }
         }
 
@@ -366,7 +376,7 @@ class Pp_Roles_Actions
                 $this->notify($out, 'success');
             }
         } else {
-            $this->notify(_('The role could not be deleted.', 'capsman-enhanced'));
+            $this->notify(__('The role could not be deleted.', 'capsman-enhanced'));
         }
     }
 
@@ -470,8 +480,7 @@ class Pp_Roles_Actions
          * If no roles provided return
          */
         if (empty($roles)) {
-            $out = __('Missing parameters, refresh the page and try again.', 'capsman-enhanced');
-            $this->notify($out);
+            $this->notify(__('Missing parameters, refresh the page and try again.', 'capsman-enhanced'));
         }
 
         $pp_only = (array) pp_capabilities_get_permissions_option( 'supplemental_role_defs' );

--- a/includes/roles/class/class-pp-roles-list-table.php
+++ b/includes/roles/class/class-pp-roles-list-table.php
@@ -77,9 +77,9 @@ class PP_Capabilities_Roles_List_Table extends WP_List_Table
     {
         $columns = [
             'cb' => '<input type="checkbox"/>', //Render a checkbox instead of text
-            'name' => __('Role Name', 'capsman-enhanced'),
-            'role' => __('Role', 'capsman-enhanced'),
-            'count' => __('Users', 'capsman-enhanced'),
+            'name' => esc_html__('Role Name', 'capsman-enhanced'),
+            'role' => esc_html__('Role', 'capsman-enhanced'),
+            'count' => esc_html__('Users', 'capsman-enhanced'),
         ];
 
         return $columns;
@@ -122,12 +122,12 @@ class PP_Capabilities_Roles_List_Table extends WP_List_Table
                         ['page' => 'pp-capabilities', 'role' => esc_attr($item['role'])], 
                         admin_url('admin.php')
                     ),
-                    __('Capabilities', 'capsman-enhanced')
+                    esc_html__('Capabilities', 'capsman-enhanced')
                 ),
             ];
         } else {
             $actions = [
-                'edit' => '<span class="pp-caps-action-note">' . __('(non-editable role)', 'capsman-enhanced') . '</span>',
+                'edit' => '<span class="pp-caps-action-note">' . esc_html__('(non-editable role)', 'capsman-enhanced') . '</span>',
             ];
 
             if (defined("PRESSPERMIT_ACTIVE")) {
@@ -147,7 +147,7 @@ class PP_Capabilities_Roles_List_Table extends WP_List_Table
                             '_wpnonce' => wp_create_nonce('bulk-roles')
                         ], 
                         admin_url('admin.php')),
-                        __('Unhide', 'capsman-enhanced')
+                        esc_html__('Unhide', 'capsman-enhanced')
                     );
                 }
             }
@@ -165,7 +165,7 @@ class PP_Capabilities_Roles_List_Table extends WP_List_Table
                         '_wpnonce' => wp_create_nonce('bulk-roles')
                     ], 
                     admin_url('admin.php')),
-                    __('Delete', 'capsman-enhanced')
+                    esc_html__('Delete', 'capsman-enhanced')
                 ),
             ]);
 
@@ -186,7 +186,7 @@ class PP_Capabilities_Roles_List_Table extends WP_List_Table
                             '_wpnonce' => wp_create_nonce('bulk-roles')
                         ], 
                         admin_url('admin.php')),
-                        __('Hide', 'capsman-enhanced')
+                        esc_html__('Hide', 'capsman-enhanced')
                     );
                 }
             }
@@ -304,7 +304,7 @@ class PP_Capabilities_Roles_List_Table extends WP_List_Table
     protected function get_bulk_actions()
     {
         $actions = [
-            'pp-roles-delete-role' => __('Delete', 'capsman-enhanced')
+            'pp-roles-delete-role' => esc_html__('Delete', 'capsman-enhanced')
         ];
 
         return $actions;
@@ -382,7 +382,7 @@ class PP_Capabilities_Roles_List_Table extends WP_List_Table
         }
         ?>
         <p class="search-box">
-            <label class="screen-reader-text" for="<?php echo esc_attr($input_id); ?>"><?php echo $text; ?>:</label>
+            <label class="screen-reader-text" for="<?php echo esc_attr($input_id); ?>"><?php echo esc_html($text); ?>:</label>
             <input type="search" id="<?php echo esc_attr($input_id); ?>" name="s"
                    value="<?php _admin_search_query(); ?>"/>
             <?php submit_button($text, '', '', false, ['id' => 'search-submit']); ?>

--- a/includes/roles/roles.php
+++ b/includes/roles/roles.php
@@ -1,11 +1,11 @@
 <div class="wrap publishpress-caps-manage pressshack-admin-wrapper pp-capability-roles-wrapper">
 
     <div class="wrap">
-        <h1 class="wp-heading-inline"><?php _e('Roles', 'capsman-enhanced') ?> </h1>
+        <h1 class="wp-heading-inline"><?php esc_html_e('Roles', 'capsman-enhanced') ?> </h1>
         <?php
         if (isset($_REQUEST['s']) && $search = esc_attr(wp_unslash($_REQUEST['s']))) {
             /* translators: %s: search keywords */
-            printf(' <span class="subtitle">' . __('Search results for &#8220;%s&#8221;', 'capsman-enhanced') . '</span>', $search);
+            printf(' <span class="subtitle">' . esc_html__('Search results for &#8220;%s&#8221;', 'capsman-enhanced') . '</span>', $search);
         }
 
         //the roles table instance
@@ -16,13 +16,13 @@
         <hr class="wp-header-end">
         <div id="ajax-response"></div>
         <form class="search-form wp-clearfix" method="get">
-            <?php $table->search_box(__('Search Roles', 'capsman-enhanced'), 'roles'); ?>
+            <?php $table->search_box(esc_html__('Search Roles', 'capsman-enhanced'), 'roles'); ?>
         </form>
         <div id="col-container" class="wp-clearfix">
             <div id="col-left">
                 <div class="col-wrap">
                     <div class="form-wrap">
-                        <h2><?php _e('Add New Role', 'capsman-enhanced') ?> </h2>
+                        <h2><?php esc_html_e('Add New Role', 'capsman-enhanced') ?> </h2>
                         <form id="addrole" method="post" action="" class="validate">
                             <input type="hidden" name="action" value="pp-roles-add-role">
                             <input type="hidden" name="screen" value="<?php echo 'capabilities_page_pp-capabilities-roles'; /*get_current_screen()->id*/ ?>">
@@ -30,14 +30,14 @@
                             wp_nonce_field('add-role');
                             ?>
                             <div class="form-field form-required">
-                                <label for="name"><?php _e('Name', 'capsman-enhanced') ?> </label>
+                                <label for="name"><?php esc_html_e('Name', 'capsman-enhanced') ?> </label>
                                 <input name="name" id="name" type="text" value="" size="40">
-                                <p><?php _e('The name is how it appears on your site.', 'capsman-enhanced'); ?></p>
+                                <p><?php esc_html_e('The name is how it appears on your site.', 'capsman-enhanced'); ?></p>
                             </div>
 
                             <p class="submit">
                                 <input type="submit" name="submit" id="submit" class="button button-primary"
-                                       value="<?php _e('Add'); ?> ">
+                                       value="<?php esc_html_e('Add'); ?> ">
                             </p>
                         </form>
                     </div>
@@ -49,7 +49,7 @@
                         <?php $table->display(); //Display the table ?>
                     </form>
                     <div class="form-wrap edit-term-notes">
-                        <p><?php __('Description here.', 'capsman-enhanced') ?></p>
+                        <p><?php esc_html__('Description here.', 'capsman-enhanced') ?></p>
                     </div>
                 </div>
             </div>

--- a/includes/settings.php
+++ b/includes/settings.php
@@ -11,7 +11,7 @@ $all_options = [];
 ?>
 
 <div class="wrap publishpress-caps-manage publishpress-caps-settings pressshack-admin-wrapper">
-    <h1><?php printf(__('Capabilities Settings', 'capsman-enhanced'), '<a href="admin.php?page=pp-capabilities">', '</a>'); ?></h1>
+    <h1><?php printf(esc_html__('Capabilities Settings', 'capsman-enhanced'), '<a href="admin.php?page=pp-capabilities">', '</a>'); ?></h1>
 
     <form class="basic-settings" method="post" action="">
         <?php wp_nonce_field('pp-capabilities-settings'); ?>
@@ -21,31 +21,31 @@ $all_options = [];
         <?php do_action('pp-capabilities-settings-ui');?>
 
         <?php if (!defined('PUBLISHPRESS_CAPS_PRO_VERSION')) :?>
-        <h3><?php _e('Related Permissions Plugins', 'capsman-enhanced');?></h3>
+        <h3><?php esc_html_e('Related Permissions Plugins', 'capsman-enhanced');?></h3>
         <ul>
             <?php $_url = "plugin-install.php?tab=plugin-information&plugin=publishpress&TB_iframe=true&width=640&height=678";
             $url = ( is_multisite() ) ? network_admin_url($_url) : admin_url($_url);
             ?>
-            <li><a class="thickbox" href="<?php echo $url;?>"><?php _e('PublishPress', 'capsman-enhanced');?></a></li>
+            <li><a class="thickbox" href="<?php echo $url;?>"><?php esc_html_e('PublishPress', 'capsman-enhanced');?></a></li>
 
             <?php $_url = "plugin-install.php?tab=plugin-information&plugin=publishpress-authors&TB_iframe=true&width=640&height=678";
             $url = ( is_multisite() ) ? network_admin_url($_url) : admin_url($_url);
             ?>
-            <li><a class="thickbox" href="<?php echo $url;?>"><?php _e('PublishPress Authors', 'capsman-enhanced');?></a></li>
+            <li><a class="thickbox" href="<?php echo $url;?>"><?php esc_html_e('PublishPress Authors', 'capsman-enhanced');?></a></li>
             </li>
             
             <?php $_url = "plugin-install.php?tab=plugin-information&plugin=press-permit-core&TB_iframe=true&width=640&height=678";
             $url = ( is_multisite() ) ? network_admin_url($_url) : admin_url($_url);
             ?>
-            <li><a class="thickbox" href="<?php echo $url;?>"><?php _e('PublishPress Permissions', 'capsman-enhanced');?></a></li>
+            <li><a class="thickbox" href="<?php echo $url;?>"><?php esc_html_e('PublishPress Permissions', 'capsman-enhanced');?></a></li>
             </li>
             
             <?php $_url = "plugin-install.php?tab=plugin-information&plugin=revisionary&TB_iframe=true&width=640&height=678";
             $url = ( is_multisite() ) ? network_admin_url($_url) : admin_url($_url);
             ?>
-            <li><a class="thickbox" href="<?php echo $url;?>"><?php _e('PublishPress Revisions', 'capsman-enhanced');?></a></li>
+            <li><a class="thickbox" href="<?php echo $url;?>"><?php esc_html_e('PublishPress Revisions', 'capsman-enhanced');?></a></li>
 
-            <li class="publishpress-contact"><a href="https://publishpress.com/contact" target="_blank"><?php _e('Help / Contact Form', 'capsman-enhanced');?></a></li>
+            <li class="publishpress-contact"><a href="https://publishpress.com/contact" target="_blank"><?php esc_html_e('Help / Contact Form', 'capsman-enhanced');?></a></li>
         </ul>
         <?php endif;?>
         
@@ -53,7 +53,7 @@ $all_options = [];
         echo "<input type='hidden' name='all_options' value='" . implode(',', $all_options) . "' />";
         ?>
 
-        <input type="submit" name="submit" id="submit" class="button button-primary" value="<?php _e('Save Changes', 'capsman-enhanced');?>">
+        <input type="submit" name="submit" id="submit" class="button button-primary" value="<?php esc_html_e('Save Changes', 'capsman-enhanced');?>">
     </form>
 
 	<?php if (!defined('PUBLISHPRESS_CAPS_PRO_VERSION') || get_option('cme_display_branding')) {


### PR DESCRIPTION
Can you guys look this over if you have time before break?  It won't be released until after New Year's but I'd like to have the changes rolled out before our external code reviews.  This is all routine hardening.

Note that we don't need to escape prior to add_menu_page(), add_submenu_page(), wp_localize_script(), ak_admin_notify() or ak_admin_error() because those functions handle it.

Input sanitizations are already added in the release-2.3.3 branch.