### PR TITLE
feature/#175_Redesign_the_Roles_screen

### DIFF
--- a/includes/roles/class/class-pp-roles-list-table.php
+++ b/includes/roles/class/class-pp-roles-list-table.php
@@ -82,51 +82,27 @@ class PP_Capabilities_Roles_List_Table extends WP_List_Table
         $views     = array();
         $current   = ' class="current"';
  
-        $this->role_views['all'] = array(
-            'label_count' => _n_noop('All %s', 'All %s', 'capsman-enhanced'),
-            'roles'       => $this->manager->get_roles_for_list_table('all')
-        );
-        
-        $this->role_views['mine'] = array(
-            'label_count' => _n_noop('Mine %s', 'Mine %s', 'capsman-enhanced'),
-            'roles'       => $this->manager->get_roles_for_list_table('mine')
-        );
+        $role_view_filters = [
+            'all'       => _n_noop('All %s', 'All %s', 'capsman-enhanced'),
+            'mine'      => _n_noop('Mine %s', 'Mine %s', 'capsman-enhanced'),
+            'active'    => _n_noop('Has Users %s', 'Has Users %s', 'capsman-enhanced'),
+            'inactive'  => _n_noop('No Users %s', 'No Users %s', 'capsman-enhanced'),
+            'editable'  => _n_noop('Editable %s', 'Editable %s', 'capsman-enhanced'),
+            'uneditable'=> _n_noop('Uneditable %s', 'Uneditable %s', 'capsman-enhanced'),
+            'system'    => _n_noop('System %s', 'System %s', 'capsman-enhanced'),
+        ];
 
-        $this->role_views['active'] = array(
-            'label_count' => _n_noop('Has Users %s', 'Has Users %s', 'capsman-enhanced'),
-            'roles'       => $this->manager->get_roles_for_list_table('active')
-        );
+        foreach($role_view_filters as $view => $noop){
+            $view_roles = $this->manager->get_roles_for_list_table($view);
+            //add role view
+            $this->role_views[$view] = ['roles' => $view_roles];
 
-        $this->role_views['inactive'] = array(
-            'label_count' => _n_noop('No Users %s', 'No Users %s', 'capsman-enhanced'),
-            'roles'       => $this->manager->get_roles_for_list_table('inactive')
-        );
-
-        $this->role_views['editable'] = array(
-            'label_count' => _n_noop('Editable %s', 'Editable %s', 'capsman-enhanced'),
-            'roles'       => $this->manager->get_roles_for_list_table('editable')
-        );
-
-        $this->role_views['uneditable'] = array(
-            'label_count' => _n_noop('Uneditable %s', 'Uneditable %s', 'capsman-enhanced'),
-            'roles'       => $this->manager->get_roles_for_list_table('uneditable')
-        );
-
-        $this->role_views['system'] = array(
-            'label_count' => _n_noop('System %s', 'System %s', 'capsman-enhanced'),
-            'roles'       => $this->manager->get_roles_for_list_table('system')
-        );
-
-        foreach ($this->role_views as $view => $args) {
-
-            $count = count($args['roles']);
+            $count = count($view_roles);
 
             // Skip any views with 0 roles.
             if ((int)$count === 0) {
                 continue;
             }
-
-            $noop = $args['label_count'];
 
             // Add the view link.
             $views[ $view ] = sprintf(

--- a/includes/roles/class/class-pp-roles-manager.php
+++ b/includes/roles/class/class-pp-roles-manager.php
@@ -14,15 +14,51 @@ class Pp_Roles_Manager
     /**
      * Returns an array of all the available roles.
      * This method is used to show the roles list table.
+     * 
+     * @param $view string
      *
      * @return array[]
      */
-    public function get_roles_for_list_table()
+    public function get_roles_for_list_table($view = 'all')
     {
+        global $wp_roles;
+
         $roles = wp_roles()->roles;
+        $current_user = wp_get_current_user();
+        $editable = function_exists('get_editable_roles') ? 
+                        array_keys(get_editable_roles()) : 
+                        array_keys(apply_filters('editable_roles', $roles));
         $count = count_users();
         $res = [];
+
         foreach ($roles as $role => $detail) {
+
+            //mine role filter
+            if ($view === 'mine' && !in_array($role, $current_user->roles)) {
+                continue;
+                //active role filter
+            } elseif ($view === 'active'
+                && (!isset($count['avail_roles'][$role])
+                || (isset($count['avail_roles'][$role]) && (int)isset($count['avail_roles'][$role]) === 0))
+            ) {
+                continue;
+                //inactive role filter
+            } elseif ($view === 'inactive'
+                && (isset($count['avail_roles'][$role])
+                && (isset($count['avail_roles'][$role]) && (int)isset($count['avail_roles'][$role]) > 0))
+            ) {
+                continue;
+                //editable role filter
+            } elseif ($view === 'editable' && !in_array($role, $editable)) {
+                continue;
+                //uneditable role filter
+            } elseif ($view === 'uneditable' && in_array($role, $editable)) {
+                continue;
+                //system role filter
+            } elseif ($view === 'system' && !$this->is_system_role($role)) {
+                continue;
+            }
+
             $res[] = [
                 'role' => $role,
                 'name' => $detail['name'],

--- a/includes/roles/roles.php
+++ b/includes/roles/roles.php
@@ -2,6 +2,9 @@
 
     <div class="wrap">
         <h1 class="wp-heading-inline"><?php esc_html_e('Roles', 'capsman-enhanced') ?> </h1>
+        <a href="<?php echo esc_url(admin_url('admin.php?page=pp-capabilities-roles')); ?>" class="page-title-action">
+            <?php esc_html_e('Add New', 'simple-tags'); ?>
+        </a>
         <?php
         if (isset($_REQUEST['s']) && $search_str = esc_attr(wp_unslash(sanitize_text_field($_REQUEST['s'])))) {
             /* translators: %s: search keywords */
@@ -19,38 +22,12 @@
             <?php $table->search_box(esc_html__('Search Roles', 'capsman-enhanced'), 'roles'); ?>
         </form>
         <div id="col-container" class="wp-clearfix">
-            <div id="col-left">
-                <div class="col-wrap">
-                    <div class="form-wrap">
-                        <h2><?php esc_html_e('Add New Role', 'capsman-enhanced') ?> </h2>
-                        <form id="addrole" method="post" action="" class="validate">
-                            <input type="hidden" name="action" value="pp-roles-add-role">
-                            <input type="hidden" name="screen" value="<?php echo 'capabilities_page_pp-capabilities-roles';?>">
-                            <?php
-                            wp_nonce_field('add-role');
-                            ?>
-                            <div class="form-field form-required">
-                                <label for="name"><?php esc_html_e('Name', 'capsman-enhanced') ?> </label>
-                                <input name="name" id="name" type="text" value="" size="40">
-                                <p><?php esc_html_e('The name is how it appears on your site.', 'capsman-enhanced'); ?></p>
-                            </div>
-
-                            <p class="submit">
-                                <input type="submit" name="submit" id="submit" class="button button-primary"
-                                       value="<?php esc_attr_e('Add'); ?> ">
-                            </p>
-                        </form>
-                    </div>
-                </div>
-            </div>
-            <div id="col-right">
-                <div class="col-wrap">
-                    <form action="" method="post">
-                        <?php $table->display(); //Display the table ?>
-                    </form>
-                    <div class="form-wrap edit-term-notes">
-                        <p><?php esc_html__('Description here.', 'capsman-enhanced') ?></p>
-                    </div>
+            <div class="col-wrap">
+                <form action="" method="post">
+                    <?php $table->display(); //Display the table ?>
+                </form>
+                <div class="form-wrap edit-term-notes">
+                    <p><?php esc_html__('Description here.', 'capsman-enhanced') ?></p>
                 </div>
             </div>
         </div>


### PR DESCRIPTION
 Feature/#175 redesign the roles screen

@agapetry @stevejburge The "Add new", "Edit" and "Copy" button are added but will only work and the action be implemented in #179 . For the copy,  i believe it's more better to simply redirect to the new UI after clicking copy so user can update name, slug and/or modify capability. So, the implementation will be done in the #179 PR as well. Here's the screen as at now:

![role](https://user-images.githubusercontent.com/46832636/155963295-145279e7-a7fa-4401-b635-a5592e01e6f2.jpg)
 