### PR TITLE
Fix bug:  Taxonomy box restrict is not effect

### DIFF
--- a/includes/features/restrict-editor-features.php
+++ b/includes/features/restrict-editor-features.php
@@ -76,7 +76,7 @@ class PP_Capabilities_Post_Features {
         
         foreach (get_taxonomies(['show_ui' => true], 'object') as $taxonomy => $tx_obj) {
             if (!in_array($taxonomy, ['category', 'post_tag', 'link_category'])) {
-                $elements[$k]["#{$tx_obj->name}div"] = ['label' => $tx_obj->label];
+                $elements[$k]["#{$tx_obj->name}div"] = ['label' => $tx_obj->label,'elements'=>"#{$tx_obj->name}, #{$tx_obj->name}div,#{$tx_obj->name}divsb,#tagsdiv-{$tx_obj->name}, th.column-{$tx_obj->name}, td.{$tx_obj->name}"];
             }
         }
 


### PR DESCRIPTION
Taxonomy box restrict is not effect when that is custom and Non-hierarchical