### PR TITLE
 feature/#367_Editor_Features_works_for_almost_everything_except_the_taxonomies_created_by_the_Toolset_plugin 

### DIFF
--- a/includes/admin-load.php
+++ b/includes/admin-load.php
@@ -18,10 +18,10 @@ class PP_Capabilities_Admin_UI {
          */
         require_once (dirname(CME_FILE) . '/classes/pp-capabilities-notices.php');
 
-        add_action('init', [$this, 'featureRestrictionsGutenberg']);
+        add_action('init', [$this, 'featureRestrictionsGutenberg'], PHP_INT_MAX - 1);
 
         if (is_admin()) {
-            add_action('admin_init', [$this, 'featureRestrictionsClassic']);
+            add_action('admin_init', [$this, 'featureRestrictionsClassic'], PHP_INT_MAX - 1);
         }
 
         add_action('admin_enqueue_scripts', [$this, 'adminScripts'], 100);


### PR DESCRIPTION
- Feature/#367 editor features works for almost everything except the taxonomies created by the toolset plugin