### PR TITLE
feature/#515_Multiple_role_when_creating_user_doesnt_work

### DIFF
--- a/common/css/profile.css
+++ b/common/css/profile.css
@@ -1,7 +1,9 @@
-tr.user-role-wrap #pp_roles_chosen li.search-choice {
+tr.user-role-wrap #pp_roles_chosen li.search-choice,
+#createuser #pp_roles_chosen li.search-choice {
     cursor: move !important;
 }
 
-tr.user-role-wrap .chosen-choice-click .chosen-drop {
+tr.user-role-wrap .chosen-choice-click .chosen-drop,
+#createuser .chosen-choice-click .chosen-drop {
     display: none !important;
 }

--- a/common/js/profile.js
+++ b/common/js/profile.js
@@ -49,23 +49,23 @@ jQuery(function ($) {
   /**
    * Make role sortable
    */
-  $(".user-role-wrap .chosen-choices").sortable();
+  $(".user-role-wrap .chosen-choices, #createuser .chosen-choices").sortable();
   
   /**
    * Force role option re-order before profile form submission
    */
-  $('form#your-profile').submit(function () {
+  $('form#your-profile, form#createuser').submit(function () {
     var options = $('#pp_roles option');
-    $(".user-role-wrap .chosen-choices .search-choice .search-choice-close").each(function () {
+    $(".user-role-wrap .chosen-choices .search-choice .search-choice-close, #createuser .chosen-choices .search-choice .search-choice-close").each(function () {
       var select_position = $(this).attr('data-option-array-index');
       $(options[select_position]).insertBefore(options.eq(0));
     });
   });
 
   /**
-   * Add class to chosen container on chouce click
+   * Add class to chosen container on choice click
    */
-	$(document).on( 'mousedown', '.user-role-wrap .chosen-choices .search-choice', function() {
+	$(document).on( 'mousedown', '.user-role-wrap .chosen-choices .search-choice, #createuser .chosen-choices .search-choice', function() {
     $(this).closest('.chosen-container').addClass('chosen-choice-click');
    });
   
@@ -73,7 +73,7 @@ jQuery(function ($) {
    * Remove chosen container class on click inside input
    */
   
-	$(document).on( 'mousedown', '.user-role-wrap .chosen-choices', function(e) {
+	$(document).on( 'mousedown', '.user-role-wrap .chosen-choices, #createuser .chosen-choices', function(e) {
     if (!e.target.parentElement.classList.contains('search-choice')) {
       $(this).closest('.chosen-container').removeClass('chosen-choice-click');
     }

--- a/includes/admin-load.php
+++ b/includes/admin-load.php
@@ -352,7 +352,9 @@ class PP_Capabilities_Admin_UI {
     public function action_profile_update($userId, $oldUserData = [])
     {
         // Check if we need to update the user's roles, allowing to set multiple roles.
-        if (!empty($_REQUEST['_wpnonce']) && wp_verify_nonce(sanitize_key($_REQUEST['_wpnonce']), 'update-user_' . $userId) && isset($_POST['pp_roles']) && current_user_can('promote_users')) {
+        if ((!empty($_REQUEST['_wpnonce']) && wp_verify_nonce(sanitize_key($_REQUEST['_wpnonce']), 'update-user_' . $userId) 
+            || !empty($_REQUEST['_wpnonce_create-user']) && wp_verify_nonce(sanitize_key($_REQUEST['_wpnonce_create-user']), 'create-user'))
+            && isset($_POST['pp_roles']) && current_user_can('promote_users')) {
             // Remove the user's roles
             $user = get_user_by('ID', $userId);
 


### PR DESCRIPTION
- Multiple role when creating user doesn’t work #515

There's a report of multiple role not been saved when enabled for new user creation 
https://wordpress.org/support/topic/multiple-role-when-creating-user-doesnt-work/

I decided to separate this from https://github.com/publishpress/PublishPress-Capabilities/issues/462 since it's a bug report and i believe should be in this week release. @agapetry 