### PR TITLE
Hotfix use create posts capability caption

### DIFF
--- a/includes/pp-ui.php
+++ b/includes/pp-ui.php
@@ -178,7 +178,7 @@ class Capsman_PP_UI {
 					<div style="margin-top:20px;margin-bottom:10px" class="ppc-tool-tip">
 					<label for="pp_define_create_posts_cap">
 					<input name="pp_define_create_posts_cap" type="checkbox" id="pp_define_create_posts_cap" autocomplete="off" value="1" <?php checked('1', $define_create_posts_cap );?> /> <?php esc_html_e('Use the "Create" capability for selected post types');?>
-                    <div class="tool-tip-text"><p><?php esc_attr_e('This will add a new capability for creating new posts. Normally, this is controlled by the "Edit" capability.', 'capsman-enhanced');?></p><i></i></div>
+                    <div class="tool-tip-text"><p><?php esc_attr_e('This will cause a new capability to be required for creating posts, and enable a checkbox column here for role assignments. Normally, post creation is controlled by the "Edit" capability.', 'capsman-enhanced');?></p><i></i></div>
 					</label>
 					</div>
 				

--- a/includes/pp-ui.php
+++ b/includes/pp-ui.php
@@ -177,7 +177,7 @@ class Capsman_PP_UI {
 				
 					<div style="margin-top:20px;margin-bottom:10px" class="ppc-tool-tip">
 					<label for="pp_define_create_posts_cap">
-					<input name="pp_define_create_posts_cap" type="checkbox" id="pp_define_create_posts_cap" autocomplete="off" value="1" <?php checked('1', $define_create_posts_cap );?> /> <?php esc_html_e('Enable the "Create" column for selected post types');?>
+					<input name="pp_define_create_posts_cap" type="checkbox" id="pp_define_create_posts_cap" autocomplete="off" value="1" <?php checked('1', $define_create_posts_cap );?> /> <?php esc_html_e('Use the "Create" capability for selected post types');?>
                     <div class="tool-tip-text"><p><?php esc_attr_e('This will add a new capability for creating new posts. Normally, this is controlled by the "Edit" capability.', 'capsman-enhanced');?></p><i></i></div>
 					</label>
 					</div>


### PR DESCRIPTION
Adjust this caption because when it's read without the tooltip, the current caption "Enable the Create column" implies this is only about enabling UI within the Role Capabilities editing screen.

Enabling this option causes standard roles like Editor and Author to no longer be able to create posts.  So it's important to emphasize that the newly available Create column becomes a new requirement to be filled, not just an optional extra assignment.