### PR TITLE
Return an empty string instead of `false` in the `admin_footer_text` filter hook callback.

### DIFF
--- a/includes/features/restrict-admin-features.php
+++ b/includes/features/restrict-admin-features.php
@@ -325,7 +325,7 @@ class PP_Capabilities_Admin_Features
             add_action('admin_head', [__CLASS__, 'contextual_help_list_remove'], 999);
         }
         if(in_array('ppc_header_footer||footer_thankyou', $ppc_header_footer)){
-            add_filter( 'admin_footer_text', '__return_false', 999 );
+            add_filter( 'admin_footer_text', '__return_empty_string', 999 );
         }
         if(in_array('ppc_header_footer||footer_upgrade', $ppc_header_footer)){
             add_filter( 'update_footer', '__return_false', 999 );


### PR DESCRIPTION
The `admin_footer_text` filter hook variable is documented as a string, see https://developer.wordpress.org/reference/hooks/admin_footer_text/, and other plugins rely on that. Returning a boolean can then create issues in other plugins that use strict type checking.