### PR TITLE
Proposal for simplifying the plugin capabilities filters routine

### DIFF
--- a/includes/extractor-capabilities.php
+++ b/includes/extractor-capabilities.php
@@ -1,1 +1,16 @@
 <?php
+
+if (!defined('ABSPATH')) {
+    exit('No direct script access allowed');
+}
+
+$activatedPlugins = get_option('active_plugins');
+
+foreach ($activatedPlugins as $plugin) {
+    $pluginName = explode('/', $plugin)[0];
+
+    $filePath = __DIR__ . '/plugin-capabilities/' . $pluginName . '.php';
+    if (is_readable($filePath)) {
+        require_once $filePath;
+    }
+}

--- a/includes/plugin-capabilities.php
+++ b/includes/plugin-capabilities.php
@@ -19,8 +19,6 @@ class Plugin_Capabilities
     {
         //PublishPress Capabilities
         add_filter('cme_plugin_capabilities', [$this, 'cme_publishpress_capabilities_capabilities']);
-        //PublishPress Planner
-        add_filter('cme_plugin_capabilities', [$this, 'cme_publishpress_capabilities']);
         //PublishPress Authors
         add_filter('cme_plugin_capabilities', [$this, 'cme_multiple_authors_capabilities']);
         //PublishPress Permissions
@@ -33,7 +31,7 @@ class Plugin_Capabilities
         add_filter('cme_plugin_capabilities', [$this, 'cme_wsform_capabilities']);
         //TaxoPress
         add_filter('cme_plugin_capabilities', [$this, 'cme_taxopress_capabilities']);
-        //WooCommerce
+        //WooCommerce`
         add_filter('cme_plugin_capabilities', [$this, 'cme_woocommerce_capabilities']);
         //Echo Knowledge Base
         add_filter('cme_plugin_capabilities', [$this, 'cme_echo_knowledge_base_capabilities']);
@@ -45,7 +43,7 @@ class Plugin_Capabilities
      * PublishPress Capabilities
      *
      * @param array $plugin_caps
-     * 
+     *
      * @return array
      */
     public function cme_publishpress_capabilities_capabilities($plugin_caps)
@@ -57,37 +55,10 @@ class Plugin_Capabilities
     }
 
     /**
-     * PublishPress Planner
-     *
-     * @param array $plugin_caps
-     * 
-     * @return array
-     */
-    public function cme_publishpress_capabilities($plugin_caps)
-    {
-
-        if (defined('PUBLISHPRESS_VERSION')) {
-            $plugin_caps['PublishPress Planner'] = apply_filters(
-                'cme_publishpress_capabilities',
-                [
-                    'edit_metadata',
-                    'edit_post_subscriptions',
-                    'pp_manage_roles',
-                    'pp_set_notification_channel',
-                    'pp_view_calendar',
-                    'pp_view_content_overview',
-                ]
-            );
-        }
-
-        return $plugin_caps;
-    }
-
-    /**
      * PublishPress Authors
      *
      * @param array $plugin_caps
-     * 
+     *
      * @return array
      */
     public function cme_multiple_authors_capabilities($plugin_caps)
@@ -106,7 +77,7 @@ class Plugin_Capabilities
      * PublishPress Permissions
      *
      * @param array $plugin_caps
-     * 
+     *
      * @return array
      */
     public function cme_presspermit_capabilities($plugin_caps)
@@ -157,7 +128,7 @@ class Plugin_Capabilities
      * Gravity Forms
      *
      * @param array $plugin_caps
-     * 
+     *
      * @return array
      */
     public function cme_gravityforms_capabilities($plugin_caps)
@@ -195,7 +166,7 @@ class Plugin_Capabilities
      * WPML
      *
      * @param array $plugin_caps
-     * 
+     *
      * @return array
      */
     public function cme_wpml_capabilities($plugin_caps)
@@ -231,7 +202,7 @@ class Plugin_Capabilities
      * WS Form
      *
      * @param array $plugin_caps
-     * 
+     *
      * @return array
      */
     public function cme_wsform_capabilities($plugin_caps)
@@ -264,7 +235,7 @@ class Plugin_Capabilities
      * TaxoPress
      *
      * @param array $plugin_caps
-     * 
+     *
      * @return array
      */
     public function cme_taxopress_capabilities($plugin_caps)
@@ -287,7 +258,7 @@ class Plugin_Capabilities
      * Echo Knowledge Base
      *
      * @param array $plugin_caps
-     * 
+     *
      * @return array
      */
     public function cme_echo_knowledge_base_capabilities($plugin_caps)
@@ -315,7 +286,7 @@ class Plugin_Capabilities
      * Yoast SEO
      *
      * @param array $plugin_caps
-     * 
+     *
      * @return array
      */
     public function cme_yoast_seo_capabilities($plugin_caps) {
@@ -326,7 +297,7 @@ class Plugin_Capabilities
                         'wpseo_bulk_edit',
                         'wpseo_edit_advanced_metadata',
                         'wpseo_manage_options'
-                    
+
                 ]
             );
         }
@@ -338,7 +309,7 @@ class Plugin_Capabilities
      * WooCommerce
      *
      * @param array $plugin_caps
-     * 
+     *
      * @return array
      */
     public function cme_woocommerce_capabilities($plugin_caps)

--- a/includes/plugin-capabilities/fluentform.php
+++ b/includes/plugin-capabilities/fluentform.php
@@ -1,0 +1,26 @@
+<?php
+
+/**
+ * PublishPress Capabilities [Free]
+ *
+ * Capabilities filters for the plugin Fluent Forms.
+ */
+
+if (!defined('ABSPATH')) {
+    exit('No direct script access allowed');
+}
+
+add_filter('cme_plugin_capabilities', function ($pluginCaps) {
+    $pluginCaps['Fluent Forms'] = [
+        'fluentform_dashboard_access',
+        'fluentform_entries_viewer',
+        'fluentform_forms_manager',
+        'fluentform_full_access',
+        'fluentform_manage_entries',
+        'fluentform_manage_payments',
+        'fluentform_settings_manager',
+        'fluentform_view_payments',
+    ];
+
+    return $pluginCaps;
+});

--- a/includes/plugin-capabilities/publishpress.php
+++ b/includes/plugin-capabilities/publishpress.php
@@ -1,0 +1,31 @@
+<?php
+
+/**
+ * PublishPress Capabilities [Free]
+ *
+ * Capabilities filters for the plugin PublishPress Planner.
+ */
+
+if (!defined('ABSPATH')) {
+    exit('No direct script access allowed');
+}
+
+add_filter('cme_plugin_capabilities', function ($pluginCaps) {
+    $caps = [
+        'edit_metadata',
+        'edit_post_subscriptions',
+        'pp_manage_roles',
+        'pp_set_notification_channel',
+        'pp_view_calendar',
+        'pp_view_content_overview',
+    ];
+
+    /**
+     * @deprecated 2.11.0
+     */
+    $caps = apply_filters_deprecated('cme_publishpress_capabilities', $caps, '2.11.0', 'cme_plugin_capabilities');
+
+    $pluginCaps['PublishPress Planner'] = $caps;
+
+    return $pluginCaps;
+});


### PR DESCRIPTION
@olatechpro You don't need to necessarily merge it. I wrote it but still needs more testing. I created the PR just to make it easier for you to follow the changes I'm proposing.

Please, let me know if you have any questions.

Some points I would like to highlight:

* Do we really need the nested apply_filters into the filter `cme_plugin_capabilities` for each plugin? That is already in a filter and could be easily modified without starting a new filter chain for every plugin iteration. We should only keep it in place where it was already released to the public, having a chance someone is using the nested filter. In this case, I suggest marking it as deprecated in favor of `cme_plugin_capabilities`.

* Move the capabilities from `plugin-capabilities.php` to a file in the `plugin-capabilities` folder. Keep it consistent for any plugin, including our plugins. I moved just PublishPress Planner's capabilities, but we should do the same for the others.

* Later we can have a simple cache on the filter `cme_plugin_capabilities`. We need a wrapper function/method for the `apply_filters('cme_plugin_capabilities',...)` call, which only runs if the cache does not exist. But we should also provide an option to disable it, refresh it, or change the cache time for example.

