### PR TITLE
Settings hander: support presspermit option_name prefix

### DIFF
--- a/includes/settings-handler.php
+++ b/includes/settings-handler.php
@@ -10,7 +10,7 @@ add_action('init', function() {
     if (check_admin_referer('pp-capabilities-settings') && current_user_can('manage_capabilities_settings')) {
         if (!empty($_POST['all_options'])) {
             foreach (array_map('sanitize_key', explode(',', sanitize_text_field($_POST['all_options']))) as $option_name) {
-                foreach (['cme_', 'capsman', 'pp_capabilities'] as $prefix) {
+                foreach (['cme_', 'capsman', 'pp_capabilities', 'presspermit'] as $prefix) {
                     if (0 === strpos($option_name, $prefix)) {
                         $value = isset($_POST[$option_name]) ? $_POST[$option_name] : '';// phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
                         $value = is_array($value) ? array_map('sanitize_text_field', $value) : sanitize_text_field($value);


### PR DESCRIPTION
This is required for a new Capabilities Pro setting which actually updates a Permissions Pro option.