### PR TITLE
Don't put default WP strings into our .pot

### DIFF
--- a/framework/lib/formating.php
+++ b/framework/lib/formating.php
@@ -37,7 +37,7 @@ function ak_admin_notify( $message = '' )
 {
     if (is_admin() && !did_action('pp_capabilities_error')) {
 	    if ( empty($message) ) {
-		    $message = esc_html__('Settings saved.', 'capability-manager-enhanced');
+		    $message = esc_html__('Settings saved.');
     	}
         // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
     	echo '<div id="message" class="updated fade"><p><strong>' . $message . '</strong></p></div>';

--- a/includes-core/admin-menus-promo.php
+++ b/includes-core/admin-menus-promo.php
@@ -45,7 +45,7 @@ $default_role = $capsman->current;
                                 ?>
                             </select> &nbsp;
                             <input type="submit" name="admin-menu-submit"
-                                value="<?php esc_attr_e('Save Changes', 'capability-manager-enhanced') ?>"
+                                value="<?php esc_attr_e('Save Changes');?>"
                                 class="button-primary ppc-admin-menu-submit" style="float:right" />
                         </div>
                         <div id="pp-capability-menu-wrapper" class="postbox" style="box-shadow: none;">

--- a/includes-core/editor-features-promo.php
+++ b/includes-core/editor-features-promo.php
@@ -93,7 +93,7 @@
         <td class="menu-column ppc-menu-item">
                 <span class="gutenberg menu-item-link">
                 <strong><i class="dashicons dashicons-arrow-right"></i> <?php esc_html_e('Custom item one', 'capability-manager-enhanced'); ?> <small>(.custom-plugin-item, #custom-plugin-item)</small> &nbsp; <span
-                        class="ppc-custom-features-delete"><small>(<?php esc_html_e('Delete', 'capability-manager-enhanced'); ?>)</small></span></strong></span>
+                        class="ppc-custom-features-delete"><small>(<?php esc_html_e('Delete'); ?>)</small></span></strong></span>
         </td>
 
         <td class="restrict-column ppc-menu-checkbox">
@@ -104,7 +104,7 @@
         <td class="menu-column ppc-menu-item">
                 <span class="gutenberg menu-item-link restricted">
                 <strong><i class="dashicons dashicons-arrow-right"></i> <?php esc_html_e('Permalink: Descriptive Caption', 'capability-manager-enhanced'); ?> <small>(.editor-post-link p)</small> &nbsp; <span
-                        class="ppc-custom-features-delete"><small>(<?php esc_html_e('Delete', 'capability-manager-enhanced'); ?>)</small></span>                </strong></span>
+                        class="ppc-custom-features-delete"><small>(<?php esc_html_e('Delete'); ?>)</small></span>                </strong></span>
         </td>
 
         <td class="restrict-column ppc-menu-checkbox">
@@ -114,7 +114,7 @@
     <tr class="ppc-menu-row parent-menu pp-promo-overlay-row pp-promo-blur">
         <td class="menu-column ppc-menu-item">
                 <span class="gutenberg menu-item-link">
-                <strong><i class="dashicons dashicons-arrow-right"></i> <?php esc_html_e('Page Attributes: Order', 'capability-manager-enhanced'); ?> <small>(.editor-page-attributes__order)</small> &nbsp; <span class="ppc-custom-features-delete"><small>(<?php esc_html_e('Delete', 'capability-manager-enhanced'); ?>)</small></span>                </strong></span>
+                <strong><i class="dashicons dashicons-arrow-right"></i> <?php esc_html_e('Page Attributes: Order', 'capability-manager-enhanced'); ?> <small>(.editor-page-attributes__order)</small> &nbsp; <span class="ppc-custom-features-delete"><small>(<?php esc_html_e('Delete'); ?>)</small></span>                </strong></span>
         </td>
 
         <td class="restrict-column ppc-menu-checkbox">

--- a/includes/admin.php
+++ b/includes/admin.php
@@ -120,7 +120,7 @@ $cme_negate_none_tooltip_msg = '<span class="tool-tip-text">
             <div style="margin-bottom: 20px;">
                 <div class="pp-capabilities-submit-top" style="float:right">
                     <?php
-                    $caption = (in_array(sanitize_key(get_locale()), ['en_EN', 'en_US'])) ? 'Save Capabilities' : __('Save Changes', 'capability-manager-enhanced');
+                    $caption = (in_array(sanitize_key(get_locale()), ['en_EN', 'en_US'])) ? 'Save Capabilities' : __('Save Changes');
                     ?>
                     <input type="submit" name="SaveRole" value="<?php echo esc_attr($caption);?>" class="button-primary" />
                 </div>
@@ -600,7 +600,7 @@ $cme_negate_none_tooltip_msg = '<span class="tool-tip-text">
 									$filter_caption = ('taxonomy' == $item_type) ? __('Filter by taxonomy', 'capability-manager-enhanced') : __('Filter by post type', 'capability-manager-enhanced');
 									echo '<option value="">' . esc_html($filter_caption) . '</option>';
 								echo '</select>';
-								echo ' <button class="button secondary-button ppc-filter-select-reset" type="button">' . esc_html__('Clear', 'capability-manager-enhanced') . '</button>';
+								echo ' <button class="button secondary-button ppc-filter-select-reset" type="button">' . __('Clear') . '</button>';
 							echo '</div>';
 
 							echo "<table class='widefat striped cme-typecaps cme-typecaps-" . esc_attr($cap_type) . "'>";
@@ -948,7 +948,7 @@ $cme_negate_none_tooltip_msg = '<span class="tool-tip-text">
 
 						echo '<div class="ppc-filter-wrapper">';
 							echo '<input type="text" class="regular-text ppc-filter-text" placeholder="' . esc_attr__('Filter by capability', 'capability-manager-enhanced') . '">';
-							echo ' <button class="button secondary-button ppc-filter-text-reset" type="button">' . esc_html__('Clear', 'capability-manager-enhanced') . '</button>';
+							echo ' <button class="button secondary-button ppc-filter-text-reset" type="button">' . __('Clear') . '</button>';
 						echo '</div>';
 						echo '<div class="ppc-filter-no-results" style="display:none;">' . esc_html__( 'No results found. Please try again with a different word.', 'capability-manager-enhanced' ) . '</div>';
 
@@ -1058,7 +1058,7 @@ $cme_negate_none_tooltip_msg = '<span class="tool-tip-text">
 
 						echo '<div class="ppc-filter-wrapper">';
 							echo '<input type="text" class="regular-text ppc-filter-text" placeholder="' . esc_attr__('Filter by capability', 'capability-manager-enhanced') . '">';
-							echo ' <button class="button secondary-button ppc-filter-text-reset" type="button">' . esc_html__('Clear', 'capability-manager-enhanced') . '</button>';
+							echo ' <button class="button secondary-button ppc-filter-text-reset" type="button">' . __('Clear') . '</button>';
 						echo '</div>';
 						echo '<div class="ppc-filter-no-results" style="display:none;">' . esc_html__( 'No results found. Please try again with a different word.', 'capability-manager-enhanced' ) . '</div>';
 
@@ -1115,7 +1115,7 @@ $cme_negate_none_tooltip_msg = '<span class="tool-tip-text">
 
 						echo '<div class="ppc-filter-wrapper">';
 							echo '<input type="text" class="regular-text ppc-filter-text" placeholder="' . esc_attr__('Filter by capability', 'capability-manager-enhanced') . '">';
-							echo ' <button class="button secondary-button ppc-filter-text-reset" type="button">' . esc_html__('Clear', 'capability-manager-enhanced') . '</button>';
+							echo ' <button class="button secondary-button ppc-filter-text-reset" type="button">' . __('Clear') . '</button>';
 						echo '</div>';
 						echo '<div class="ppc-filter-no-results" style="display:none;">' . esc_html__( 'No results found. Please try again with a different word.', 'capability-manager-enhanced' ) . '</div>';
 
@@ -1331,7 +1331,7 @@ $cme_negate_none_tooltip_msg = '<span class="tool-tip-text">
 
 						echo '<div class="ppc-filter-wrapper">';
 							echo '<input type="text" class="regular-text ppc-filter-text" placeholder="' . esc_attr__('Filter by capability', 'capability-manager-enhanced') . '">';
-							echo ' <button class="button secondary-button ppc-filter-text-reset" type="button">' . esc_html__('Clear', 'capability-manager-enhanced') . '</button>';
+							echo ' <button class="button secondary-button ppc-filter-text-reset" type="button">' . __('Clear') . '</button>';
 						echo '</div>';
 						echo '<div class="ppc-filter-no-results" style="display:none;">' . esc_html__( 'No results found. Please try again with a different word.', 'capability-manager-enhanced' ) . '</div>';
 						?>
@@ -1737,7 +1737,7 @@ $cme_negate_none_tooltip_msg = '<span class="tool-tip-text">
 			<input type="hidden" name="current" value="<?php echo esc_attr($default); ?>" />
 
 			<?php
-			$save_caption = (in_array(sanitize_key(get_locale()), ['en_EN', 'en_US'])) ? 'Save Capabilities' : __('Save Changes', 'capability-manager-enhanced');
+			$save_caption = (in_array(sanitize_key(get_locale()), ['en_EN', 'en_US'])) ? 'Save Capabilities' : __('Save Changes');
 			?>
 			<input type="submit" name="SaveRole" value="<?php echo esc_attr($save_caption);?>" class="button-primary" /> &nbsp;
 		</p>

--- a/includes/backup.php
+++ b/includes/backup.php
@@ -337,7 +337,7 @@ $sidebar_enabled = defined('PUBLISHPRESS_CAPS_PRO_VERSION') ? false : true;
                                         </p>
                                         <p>
                                             <input type="submit" name="import_backup"
-                                                    value="<?php esc_attr_e('Import', 'capability-manager-enhanced') ?>"
+                                                    value="<?php esc_attr_e('Import'); ?>"
                                                     class="button-primary"/>
                                         </p>
                                     </div>

--- a/includes/features/admin-features.php
+++ b/includes/features/admin-features.php
@@ -51,7 +51,7 @@ $admin_features_elements = PP_Capabilities_Admin_Features::elementsLayout();
                                         <div class="publishpress-filters">
                                             <div class="pp-capabilities-submit-top" style="float:right;">
                                                 <input type="submit" name="admin-features-submit"
-                                                    value="<?php esc_attr_e('Save Changes', 'capability-manager-enhanced') ?>"
+                                                    value="<?php esc_attr_e('Save Changes');?>"
                                                     class="button-primary ppc-admin-features-submit" />
                                             </div>
 
@@ -218,7 +218,7 @@ $admin_features_elements = PP_Capabilities_Admin_Features::elementsLayout();
                                                                                 </div>
                                                                             </div>
                                                                             <div class="ppc-flex-item">
-                                                                                <div class="button view-custom-item"><?php esc_html_e('View', 'capability-manager-enhanced'); ?></div>
+                                                                                <div class="button view-custom-item"><?php esc_html_e('View'); ?></div>
                                                                                     <?php /*<div class="button edit-custom-item" 
                                                                                         data-section="<?php echo esc_attr($section_slug); ?>"
                                                                                         data-label="<?php echo esc_attr($section_array['label']); ?>"
@@ -232,7 +232,7 @@ $admin_features_elements = PP_Capabilities_Admin_Features::elementsLayout();
                                                                                     <div 
                                                                                         class="button <?php echo esc_attr($section_array['button_class']); ?> feature-red"
                                                                                         data-id="<?php echo esc_attr($section_array['button_data_id']); ?>">
-                                                                                        <?php esc_html_e('Delete', 'capability-manager-enhanced'); ?>    
+                                                                                        <?php esc_html_e('Delete'); ?>    
                                                                                     </div>
                                                                                 </div>
                                                                             </div>
@@ -280,7 +280,7 @@ $admin_features_elements = PP_Capabilities_Admin_Features::elementsLayout();
                                         </div>
                                     </div>
                                     <input type="submit" name="admin-features-submit"
-                                           value="<?php esc_attr_e('Save Changes', 'capability-manager-enhanced') ?>"
+                                           value="<?php esc_attr_e('Save Changes');?>"
                                            class="button-primary ppc-admin-features-submit"/>
                                 </td>
                             </tr>

--- a/includes/features/editor-features-classic.php
+++ b/includes/features/editor-features-classic.php
@@ -98,7 +98,7 @@
                             </div>
                         </div>
                         <div class="ppc-flex-item">
-                            <div class="button view-custom-item"><?php esc_html_e('View', 'capability-manager-enhanced'); ?></div>
+                            <div class="button view-custom-item"><?php esc_html_e('View'); ?></div>
                                 <?php /*<div class="button edit-custom-item" 
                                     data-section="<?php echo esc_attr($section_slug); ?>"
                                     data-label="<?php echo esc_attr($section_array['label']); ?>"
@@ -113,7 +113,7 @@
                                     class="button <?php echo esc_attr($arr_feature['button_class']); ?> feature-red" 
                                     data-parent="<?php echo esc_attr($arr_feature['button_data_parent']); ?>" 
                                     data-id="<?php echo esc_attr($arr_feature['button_data_id']); ?>">
-                                    <?php esc_html_e('Delete', 'capability-manager-enhanced'); ?>    
+                                    <?php esc_html_e('Delete'); ?>    
                                 </div>
                             </div>
                         </div>

--- a/includes/features/editor-features-gutenberg.php
+++ b/includes/features/editor-features-gutenberg.php
@@ -95,7 +95,7 @@
                         </div>
                     </div>
                     <div class="ppc-flex-item">
-                        <div class="button view-custom-item"><?php esc_html_e('View', 'capability-manager-enhanced'); ?></div>
+                        <div class="button view-custom-item"><?php esc_html_e('View'); ?></div>
                             <?php /*<div class="button edit-custom-item" 
                                 data-section="<?php echo esc_attr($section_slug); ?>"
                                 data-label="<?php echo esc_attr($section_array['label']); ?>"
@@ -110,7 +110,7 @@
                                 class="button <?php echo esc_attr($arr_feature['button_class']); ?> feature-red" 
                                 data-parent="<?php echo esc_attr($arr_feature['button_data_parent']); ?>" 
                                 data-id="<?php echo esc_attr($arr_feature['button_data_id']); ?>">
-                                <?php esc_html_e('Delete', 'capability-manager-enhanced'); ?>    
+                                <?php esc_html_e('Delete'); ?>    
                             </div>
                         </div>
                     </div>

--- a/includes/features/frontend-features/frontend-features-ui.php
+++ b/includes/features/frontend-features/frontend-features-ui.php
@@ -251,7 +251,7 @@ class PP_Capabilities_Frontend_Features_UI
                 </div>
             </td>
             <td>
-                <div class="button view-custom-item"><?php esc_html_e('View', 'capability-manager-enhanced'); ?></div>
+                <div class="button view-custom-item"><?php esc_html_e('View'); ?></div>
             </td>
             <td>
                 <div class="button edit-custom-item" 
@@ -262,7 +262,7 @@ class PP_Capabilities_Frontend_Features_UI
                     data-pages="<?php echo esc_attr(join(', ', (array) $section_array['pages'])); ?>"
                     data-post-types="<?php echo esc_attr(join(', ', (array) $section_array['post_types'])); ?>"
                     data-id="<?php echo esc_attr($section_id); ?>">
-                <?php esc_html_e('Edit', 'capability-manager-enhanced'); ?>
+                <?php esc_html_e('Edit'); ?>
                 </div>
             </td>
             <td>
@@ -271,7 +271,7 @@ class PP_Capabilities_Frontend_Features_UI
                     data-section="<?php echo esc_attr($section_slug); ?>" 
                     data-id="<?php echo esc_attr($section_id); ?>" 
                     data-delete-nonce="<?php echo esc_attr(wp_create_nonce('frontend-delete' . $section_id .'-nonce')); ?>">
-                    <?php esc_html_e('Delete', 'capability-manager-enhanced'); ?>    
+                    <?php esc_html_e('Delete'); ?>    
                 </div>
             </td>
         </tr>

--- a/includes/features/frontend-features/frontend-features.php
+++ b/includes/features/frontend-features/frontend-features.php
@@ -82,7 +82,7 @@ $frontend_features_elements = PP_Capabilities_Frontend_Features_Data::elementsLa
                             <div class="publishpress-filters">
                                 <div class="pp-capabilities-submit-top" style="float:right;">
                                     <input type="submit" name="frontend-features-submit"
-                                        value="<?php esc_attr_e('Save Changes', 'capability-manager-enhanced') ?>"
+                                        value="<?php esc_attr_e('Save Changes');?>"
                                         class="button-primary ppc-frontend-features-submit" />
                                 </div>
 
@@ -232,7 +232,7 @@ $frontend_features_elements = PP_Capabilities_Frontend_Features_Data::elementsLa
                             <div class="editor-features-footer-meta">
                                 <div style="float:right">
                                     <input type="submit" name="frontend-features-submit"
-                                        value="<?php esc_attr_e('Save Changes', 'capability-manager-enhanced') ?>"
+                                        value="<?php esc_attr_e('Save Changes');?>"
                                         class="button-primary ppc-frontend-features-submit" />
                                 </div>
                             </div>

--- a/includes/features/nav-menus.php
+++ b/includes/features/nav-menus.php
@@ -98,7 +98,7 @@ $nav_menu_item_option = array_key_exists($default_role, $nav_menu_item_option) ?
                                         <img class="loading" src="<?php echo esc_url($capsman->mod_url); ?>/images/wpspin_light.gif" style="display: none">
 
                                         <input type="submit" name="nav-menu-submit"
-                                            value="<?php esc_attr_e('Save Changes', 'capability-manager-enhanced') ?>"
+                                            value="<?php esc_attr_e('Save Changes');?>"
                                             class="button-primary ppc-nav-menu-submit" style="float:right" />
                                     </div>
 
@@ -288,7 +288,7 @@ $nav_menu_item_option = array_key_exists($default_role, $nav_menu_item_option) ?
                                         </div>
                                     </div>
                                     <input type="submit" name="nav-menu-submit"
-                                        value="<?php esc_attr_e('Save Changes', 'capability-manager-enhanced') ?>"
+                                        value="<?php esc_attr_e('Save Changes');?>"
                                         class="button-primary ppc-nav-menu-submit"/>
 
                                 </td>

--- a/includes/features/profile-features.php
+++ b/includes/features/profile-features.php
@@ -57,7 +57,7 @@ if (get_option('cme_profile_features_auto_redirect')) {
                                         <div class="publishpress-filters">
                                             <div class="pp-capabilities-submit-top" style="float:right;">
                                                 <input type="submit" name="profile-features-submit"
-                                                    value="<?php esc_attr_e('Save Changes', 'capability-manager-enhanced') ?>"
+                                                    value="<?php esc_attr_e('Save Changes');?>"
                                                     class="button-primary ppc-profile-features-submit" />
                                             </div>
 
@@ -211,7 +211,7 @@ if (get_option('cme_profile_features_auto_redirect')) {
                                     </div>
                                     <input type="hidden" name="capsman_profile_features_elements_order" class="capsman_profile_features_elements_order" value=""/>
                                     <input type="submit" name="profile-features-submit"
-                                           value="<?php esc_attr_e('Save Changes', 'capability-manager-enhanced') ?>"
+                                           value="<?php esc_attr_e('Save Changes');?>"
                                            class="button-primary ppc-profile-features-submit"/>
                                 </td>
                             </tr>

--- a/includes/features/restrict-admin-features.php
+++ b/includes/features/restrict-admin-features.php
@@ -59,8 +59,8 @@ class PP_Capabilities_Admin_Features
         $title['menu-toggle']      = esc_html__('Mobile Menu Toggle', 'capability-manager-enhanced');
         $title['wp-logo']          = esc_html__('WordPress Logo', 'capability-manager-enhanced');
         $title['wp-logo-external'] = esc_html__('WordPress External Links', 'capability-manager-enhanced');
-        $title['updates']          = esc_html__('Updates', 'capability-manager-enhanced');
-        $title['comments']         = esc_html__('Comments', 'capability-manager-enhanced');
+        $title['updates']          = esc_html__('Updates');
+        $title['comments']         = esc_html__('Comments');
         $title['top-secondary']    = esc_html__('Right bar', 'capability-manager-enhanced');
         $title['user-actions']     = esc_html__('User actions', 'capability-manager-enhanced');
         $title['new-content']      = esc_html__('New', 'capability-manager-enhanced');
@@ -78,8 +78,8 @@ class PP_Capabilities_Admin_Features
      */
     public static function formatHeaderFooter()
     {
-        $elements_item['screen_options'] = ['label'  => esc_html__('Screen Options', 'capability-manager-enhanced'), 'action' => 'ppc_header_footer'];
-        $elements_item['screen_help'] = ['label'  => esc_html__('Help', 'capability-manager-enhanced'), 'action' => 'ppc_header_footer'];
+        $elements_item['screen_options'] = ['label'  => esc_html__('Screen Options'), 'action' => 'ppc_header_footer'];
+        $elements_item['screen_help'] = ['label'  => esc_html__('Help'), 'action' => 'ppc_header_footer'];
         $elements_item['footer_thankyou'] = ['label'  => esc_html__('Thank you for creating with WordPress', 'capability-manager-enhanced'), 'action' => 'ppc_header_footer'];
         $elements_item['footer_upgrade'] = ['label'  => sprintf( esc_html__( 'Version %s' ), get_bloginfo('version'), 'capability-manager-enhanced' ), 'action' => 'ppc_header_footer'];
 

--- a/includes/features/restrict-editor-features.php
+++ b/includes/features/restrict-editor-features.php
@@ -38,25 +38,25 @@ class PP_Capabilities_Post_Features {
         $elements = [];
 
         $elements[esc_html__('Top Tabs', 'capability-manager-enhanced')] = [
-            '#contextual-help-link-wrap' => ['label' => esc_html__('Help', 'capability-manager-enhanced')],
-            '#screen-options-link-wrap' => ['label' => esc_html__('Screen Options', 'capability-manager-enhanced')],
+            '#contextual-help-link-wrap' => ['label' => esc_html__('Help')],
+            '#screen-options-link-wrap' => ['label' => esc_html__('Screen Options')],
         ];
 
-        $elements[esc_html__('Editor', 'capability-manager-enhanced')] = [
+        $elements[esc_html(_x( 'Editor', 'site editor menu item' ))] = [
             '.page-title-action' => [
                 'label' => esc_html__('Add New', 'capability-manager-enhanced')
             ],
             '#title' => [
-                'label'       => esc_html__('Title', 'capability-manager-enhanced'), 
+                'label'       => esc_html__('Title'), 
                 'elements'    => '#titlediv, #title, #titlewrap', 
                 'support_key' => 'title'
             ],
             '#postdivrich' => [
-                'label'       => esc_html__('Editor', 'capability-manager-enhanced'), 
+                'label'       => esc_html(_x( 'Editor', 'site editor menu item' )), 
                 'support_key' => 'editor'
             ],
             '#pageslugdiv' => [
-                'label' => esc_html__('Permalink', 'capability-manager-enhanced')
+                'label' => esc_html__('Slug', 'capability-manager-enhanced')
             ],
             '#media_buttons' => [
                 'label'       => esc_html__('Media Buttons (all)', 'capability-manager-enhanced'), 
@@ -76,33 +76,33 @@ class PP_Capabilities_Post_Features {
 
         $elements[esc_html__('Publish Box', 'capability-manager-enhanced')] = [
             '#submitdiv' => ['label' => esc_html__('Publish Box', 'capability-manager-enhanced')],
-            '#save-post' => ['label' => esc_html__('Save Draft', 'capability-manager-enhanced')],
-            '#post-preview' => ['label' => esc_html__('Preview', 'capability-manager-enhanced')],
-            '.misc-pub-post-status' => ['label' => esc_html__('Publish Status ', 'capability-manager-enhanced')],
-            '.misc-pub-visibility' => ['label' => esc_html__('Publish Visibility', 'capability-manager-enhanced')],
-            '#sticky-span' => ['label' => esc_html__('Stick this post to the front page', 'capability-manager-enhanced')],
-            '#passworddiv' => ['label' => esc_html__('Password Protect This Post', 'capability-manager-enhanced')],
+            '#save-post' => ['label' => esc_html__('Save Draft')],
+            '#post-preview' => ['label' => esc_html__('Preview')],
+            '.misc-pub-post-status' => ['label' => esc_html__('Status')],
+            '.misc-pub-visibility' => ['label' => esc_html__('Visibility')],
+            '#sticky-span' => ['label' => esc_html__('Stick this post to the front page')],
+            '#passworddiv' => ['label' => esc_html__('Password protected')],
             '#misc-publishing-actions' => ['label' => esc_html__('Publish Actions', 'capability-manager-enhanced')],
-            '.misc-pub-curtime' => ['label' => esc_html__('Publish Schedule', 'capability-manager-enhanced')],
-            '#date' => ['label' => esc_html__('Date', 'capability-manager-enhanced'),                            'elements' => '#date, #datediv, th.column-date, td.date, div.curtime'],
-            '#publish' => ['label' => esc_html__('Publish', 'capability-manager-enhanced')],
+            '.misc-pub-curtime' => ['label' => sprintf(esc_html__('Publish on: %s'), '')],
+            '#date' => ['label' => esc_html__('Date'),     'elements' => '#date, #datediv, th.column-date, td.date, div.curtime'],
+            '#publish' => ['label' => esc_html__('Publish')],
         ];
 
         $elements[esc_html__('Taxonomy Boxes', 'capability-manager-enhanced')] = [
             '#category' => [
-                'label'        => esc_html__('Categories', 'capability-manager-enhanced'),
+                'label'        => esc_html__('Categories'),
                 'elements'     => '#categories, #categorydiv, #categorydivsb, th.column-categories, td.categories, #screen-options-wrap label[for=categorydiv-hide]',
                 'support_key'  => 'category',
                 'support_type' => 'taxonomy'
             ],
             '#category-add-toggle' => [
-                'label'        => esc_html__('Add New Category', 'capability-manager-enhanced'),
+                'label'        => esc_html__('Add New Category'),
                 'elements'     => '#category-add-toggle',
                 'support_key'  => 'category',
                 'support_type' => 'taxonomy'
             ],
             '#post_tag' => [
-                'label'       => esc_html__('Tags', 'capability-manager-enhanced'), 
+                'label'       => esc_html__('Tags'), 
                 'elements'    => '#tags, #tagsdiv,#tagsdivsb,#tagsdiv-post_tag, th.column-tags, td.tags, #screen-options-wrap label[for=tagsdiv-post_tag-hide]',
                 'support_key' => 'post_tag',
                 'support_type' => 'taxonomy'
@@ -125,21 +125,21 @@ class PP_Capabilities_Post_Features {
 
         $elements[esc_html__('Page Boxes', 'capability-manager-enhanced')] = [
             '#pageparentdiv' => [
-                'label'       => esc_html__('Page Attributes', 'capability-manager-enhanced'),
+                'label'       => esc_html__('Page Attributes'),
                 'support_key' => 'page-attributes'
             ],
             '#parent_id' => [
-                'label'       => esc_html__('Parent', 'capability-manager-enhanced'), 
+                'label'       => esc_html__('Parent'), 
                 'elements'    => 'p.parent-id-label-wrapper, #parent_id',
                 'support_key' => 'page-attributes'
             ],
             '#page_template' => [
-                'label' => esc_html__('Page Template', 'capability-manager-enhanced'),
+                'label' => esc_html__('Template'),
                 'elements'    => '#page_template',
                 'support_key' => 'page-attributes'
             ],
             'p.menu-order-label-wrapper' => [
-                'label'       => esc_html__('Order', 'capability-manager-enhanced'),
+                'label'       => esc_html__('Order'),
                 'elements'    => 'p.menu-order-label-wrapper',
                 'support_key' => 'page-attributes'
             ],
@@ -152,11 +152,11 @@ class PP_Capabilities_Post_Features {
                 'support_key' => 'thumbnail'
             ],
             '#slug' => [
-                'label' => esc_html__('Post Slug', 'capability-manager-enhanced'),
+                'label' => esc_html__('Slug'),
                 'elements' => '#slugdiv,#edit-slug-box, #screen-options-wrap label[for=slugdiv-hide]'
             ],
             '#commentstatusdiv' => [
-                'label' => esc_html__('Discussion', 'capability-manager-enhanced'),
+                'label' => esc_html__('Discussion'),
                 'elements'    => '#commentstatusdiv, #screen-options-wrap label[for=commentstatusdiv-hide]',
                 'support_key' => 'comments'
             ],
@@ -383,29 +383,29 @@ class PP_Capabilities_Post_Features {
             esc_html__('Top Bar - Left', 'capability-manager-enhanced') => [
                 'add_block' => ['label' => esc_html__('Add block', 'capability-manager-enhanced'), 'elements' => '.edit-post-header-toolbar .edit-post-header-toolbar__inserter-toggle.has-icon'],
                 'modes' =>     ['label' => esc_html__('Modes', 'capability-manager-enhanced'),     'elements' => '.edit-post-header-toolbar .components-dropdown:first-of-type'],
-                'undo' =>      ['label' => esc_html__('Undo', 'capability-manager-enhanced'),      'elements' => '.edit-post-header-toolbar .editor-history__undo'],
-                'redo' =>      ['label' => esc_html__('Redo', 'capability-manager-enhanced'),      'elements' => '.edit-post-header-toolbar .editor-history__redo'],
-                'details' =>   ['label' => esc_html__('Details', 'capability-manager-enhanced'),   'elements' => '.edit-post-header__toolbar .table-of-contents'],
+                'undo' =>      ['label' => esc_html__('Undo'),                       'elements' => '.edit-post-header-toolbar .editor-history__undo'],
+                'redo' =>      ['label' => esc_html__('Redo'),                       'elements' => '.edit-post-header-toolbar .editor-history__redo'],
+                'details' =>   ['label' => esc_html__('Details'),                     'elements' => '.edit-post-header__toolbar .table-of-contents'],
                 'outline' =>   ['label' => esc_html__('Outline', 'capability-manager-enhanced'),   'elements' => '.edit-post-header__toolbar .edit-post-header-toolbar__list-view-toggle'],
             ],
 
             esc_html__('Top Bar - Right', 'capability-manager-enhanced') => [
-                'save_draft' =>       ['label' => esc_html__('Save Draft', 'capability-manager-enhanced'),       'elements' => '.edit-post-header__settings .components-button.editor-post-save-draft'],
-                'switch_to_draft' =>  ['label' => esc_html__('Switch to draft', 'capability-manager-enhanced'),  'elements' => '.edit-post-header__settings .components-button.editor-post-switch-to-draft'],
-                'preview' =>          ['label' => esc_html__('Preview', 'capability-manager-enhanced'),          'elements' => '.edit-post-header__settings .block-editor-post-preview__dropdown'],
+                'save_draft' =>       ['label' => esc_html__('Save Draft'),                        'elements' => '.edit-post-header__settings .components-button.editor-post-save-draft'],
+                'switch_to_draft' =>  ['label' => esc_html__('Switch to Draft'),                   'elements' => '.edit-post-header__settings .components-button.editor-post-switch-to-draft'],
+                'preview' =>          ['label' => esc_html__('Preview'),                           'elements' => '.edit-post-header__settings .block-editor-post-preview__dropdown'],
                 'publish' =>          ['label' => esc_html__('Publish / Update', 'capability-manager-enhanced'), 'elements' => '.edit-post-header__settings .editor-post-publish-button__button'],
-                'settings' =>         ['label' => esc_html__('Settings', 'capability-manager-enhanced'),         'elements' => '.edit-post-header__settings .interface-pinned-items button'],
+                'settings' =>         ['label' => esc_html__('Settings'),                          'elements' => '.edit-post-header__settings .interface-pinned-items button'],
                 'options' =>          ['label' => esc_html__('Options', 'capability-manager-enhanced'),          'elements' => '.edit-post-header__settings .edit-post-more-menu .components-button, .edit-post-header__settings .components-dropdown-menu.interface-more-menu-dropdown'],
             ],
 
             esc_html__('Body', 'capability-manager-enhanced') => [
                 'edit_title' =>   [
-                    'label'       => esc_html__('Edit title', 'capability-manager-enhanced'), 
+                    'label'       => esc_html__('Title'), 
                     'elements'    => '.wp-block.editor-post-title__block, .wp-block.editor-post-title',
                     'support_key' => 'title'
                 ],
                 'content' =>      [
-                    'label'       => esc_html__('Content', 'capability-manager-enhanced'), 
+                    'label'       => esc_html__('Content'), 
                     'elements'    => '.block-editor-block-list__layout',
                     'support_key' => 'editor'
                 ],
@@ -418,20 +418,20 @@ class PP_Capabilities_Post_Features {
             esc_html__('Document Panel', 'capability-manager-enhanced') => [
                 'status_visibility' => ['label' => esc_html__('Status & visibility', 'capability-manager-enhanced'),   'elements' => 'post-status'],
                 'template'          => [
-                    'label'       => esc_html__('Template', 'capability-manager-enhanced'),
+                    'label'       => esc_html__('Template'),
                     'elements'    => '.components-panel__row.edit-post-post-template'
                 ],
-                'revisions'         => ['label' => esc_html__('Revisions', 'capability-manager-enhanced'), 'elements' => '.editor-post-last-revision__title'],
+                'revisions'         => ['label' => esc_html__('Revisions'), 'elements' => '.editor-post-last-revision__title'],
                 'permalink' =>         ['label' => esc_html__('Permalink', 'capability-manager-enhanced'), 'elements' => '.components-panel__row.edit-post-post-url'],
-                'sticky'    =>         ['label' => esc_html__('Stick to the top of the blog', 'capability-manager-enhanced'), 'elements' => '.components-panel .components-panel__body.edit-post-post-status .edit-post-post-url + .components-panel__row'],
+                'sticky'    =>         ['label' => esc_html__( 'Stick this post to the front page' ) , 'elements' => '.components-panel .components-panel__body.edit-post-post-status .edit-post-post-url + .components-panel__row'],
                 'categories' =>        [
-                    'label'        => esc_html__('Categories', 'capability-manager-enhanced'), 
+                    'label'        => esc_html__('Categories'), 
                     'elements'     => 'taxonomy-panel-category',
                     'support_key'  => 'category',
                     'support_type' => 'taxonomy'
                 ],
                 'tags' =>              [
-                    'label'        => esc_html__('Tags', 'capability-manager-enhanced'),
+                    'label'        => esc_html__('Tags'),
                     'elements'     => 'taxonomy-panel-post_tag',
                     'support_key'  => 'post_tag',
                     'support_type' => 'taxonomy'
@@ -460,12 +460,12 @@ class PP_Capabilities_Post_Features {
                 'support_key' => 'thumbnail'
             ],
             'excerpt'         => [
-                'label'       => esc_html__('Excerpt', 'capability-manager-enhanced'),
+                'label'       => esc_html__('Excerpt'),
                 'elements'    => 'post-excerpt',
                 'support_key' => 'excerpt'
             ],
             'discussion'      => [
-                'label'       => esc_html__('Discussion', 'capability-manager-enhanced'), 
+                'label'       => esc_html__('Discussion'), 
                 'elements'    => 'discussion-panel',
                 'support_key' => 'comments'
             ],

--- a/includes/functions-admin.php
+++ b/includes/functions-admin.php
@@ -230,7 +230,7 @@ function pp_capabilities_backup_sections()
    $backup_sections['capsman_nav_menu_backup']['options'][] = "capsman_nav_item_menus";
 
    //settings
-   $backup_sections['capsman_settings_backup']['label']     = esc_html__('Settings', 'capability-manager-enhanced');
+   $backup_sections['capsman_settings_backup']['label']     = esc_html__('Settings');
    $backup_sections['capsman_settings_backup']['options']   = pp_capabilities_settings_options();
 
    return apply_filters('pp_capabilities_backup_sections', $backup_sections);
@@ -413,7 +413,7 @@ function pp_capabilities_sub_menu_lists($cme_fakefunc = false) {
 
     $sub_menu_pages = [];
     $sub_menu_pages['dashboard'] = [
-        'title'             => __('Dashboard', 'capability-manager-enhanced'),
+        'title'             => __('Dashboard'),
         'capabilities'      => $super_user ? 'read' : 'manage_capabilities_dashboard',
         'page'              => 'pp-capabilities-dashboard',
         'callback'          => $cme_fakefunc ? 'cme_fakefunc' : [$capsman, 'dashboardPage'],
@@ -485,7 +485,7 @@ function pp_capabilities_sub_menu_lists($cme_fakefunc = false) {
         'dashboard_control' => false,
     ];
     $sub_menu_pages['settings'] = [
-        'title'             => __('Settings', 'capability-manager-enhanced'),
+        'title'             => __('Settings'),
         'capabilities'      => $super_user ? 'read' : 'manage_capabilities_settings',
         'page'              => 'pp-capabilities-settings',
         'callback'          => $cme_fakefunc ? 'cme_fakefunc' : [$capsman, 'settingsPage'],

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -786,12 +786,12 @@ function ppc_block_friend_name($block_name) {
     $friendly_name = $block_name;
 
     $supported_blocks = [
-        'core/site-logo'     => __('Site Logo', 'capability-manager-enhanced'),
-        'core/site-title'    => __('Site Title', 'capability-manager-enhanced'),
+        'core/site-logo'     => __('Logo'),
+        'core/site-title'    => __('Site Title'),
         'core/social-links'  => __('Social Links', 'capability-manager-enhanced'),
         'core/page-list'     => __('Page Lists', 'capability-manager-enhanced'),
-        'core/search'        => __('Search', 'capability-manager-enhanced'),
-        'core/home-link'     => __('Home Link', 'capability-manager-enhanced'),
+        'core/search'        => __('Search'),
+        'core/home-link'     => _x( 'Home', 'nav menu home label' ),
     ];
 
     if (array_key_exists($block_name, $supported_blocks)) {

--- a/includes/manager.php
+++ b/includes/manager.php
@@ -426,6 +426,7 @@ class CapabilityManager
         $dashboard_screen = (isset($_GET['page']) && $_GET['page'] === $cap_page_slug) ? true : false;
         $submenu_slugs              = [];
         $submenu_slugs_conditions   = [];
+
         foreach ($sub_menu_pages as $feature => $subpage_option) {
             if ($subpage_option['dashboard_control'] === false 
                 || pp_capabilities_feature_enabled($feature)
@@ -485,7 +486,7 @@ class CapabilityManager
                     return [
                         'cb' 			  => '<input type="checkbox"/>',
                         'name'            => esc_html__('Role Name', 'capability-manager-enhanced'),
-						'count'           => esc_html__('Users', 'capability-manager-enhanced'),
+						'count'           => esc_html__('Users'),
 						'role_type'       => esc_html__('Role Type', 'capability-manager-enhanced'),
 						'default_role'    => esc_html__('Default Role', 'capability-manager-enhanced'),
 						'admin_access'    => esc_html__('Admin Access', 'capability-manager-enhanced'),

--- a/includes/roles/class/class-pp-roles-admin.php
+++ b/includes/roles/class/class-pp-roles-admin.php
@@ -131,7 +131,7 @@ class Pp_Roles_Admin
 
         if ($role_edit && !$current['is_system']) {
             $fields_tabs['delete'] = [
-                'label'    => esc_html__('Delete', 'capability-manager-enhanced'),
+                'label'    => esc_html__('Delete'),
                 'icon'     => 'dashicons dashicons-trash',
             ];
         }

--- a/includes/roles/class/class-pp-roles-list-table.php
+++ b/includes/roles/class/class-pp-roles-list-table.php
@@ -168,7 +168,7 @@ class PP_Capabilities_Roles_List_Table extends WP_List_Table
         $columns = [
             'cb'              => '<input type="checkbox"/>', //Render a checkbox instead of text
             'name'            => esc_html__('Role Name', 'capability-manager-enhanced'),
-            'count'           => esc_html__('Users', 'capability-manager-enhanced'),
+            'count'           => esc_html__('Users'),
             'role_type'       => esc_html__('Role Type', 'capability-manager-enhanced'),
             'default_role'    => esc_html__('Default Role', 'capability-manager-enhanced'),
             'admin_access'    => esc_html__('Admin Access', 'capability-manager-enhanced'),
@@ -219,7 +219,7 @@ class PP_Capabilities_Roles_List_Table extends WP_List_Table
                         admin_url('admin.php')
                     )
                 ),
-                esc_html__('Edit', 'capability-manager-enhanced')
+                esc_html__('Edit')
             );
             
             $actions['copy'] = sprintf(
@@ -271,7 +271,7 @@ class PP_Capabilities_Roles_List_Table extends WP_List_Table
                         '_wpnonce' => wp_create_nonce('bulk-roles')
                     ], 
                     admin_url('admin.php')),
-                    esc_html__('Delete', 'capability-manager-enhanced')
+                    esc_html__('Delete')
                 ),
             ]);
 
@@ -290,7 +290,7 @@ class PP_Capabilities_Roles_List_Table extends WP_List_Table
                             '_wpnonce' => wp_create_nonce('bulk-roles')
                         ], 
                         admin_url('admin.php')),
-                        esc_html__('Hide', 'capability-manager-enhanced')
+                        esc_html__('Hide')
                     );
                 }
             }
@@ -506,7 +506,7 @@ class PP_Capabilities_Roles_List_Table extends WP_List_Table
     protected function get_bulk_actions()
     {
         $actions = [
-            'pp-roles-delete-role' => esc_html__('Delete', 'capability-manager-enhanced')
+            'pp-roles-delete-role' => esc_html__('Delete')
         ];
 
         return $actions;

--- a/includes/roles/roles.php
+++ b/includes/roles/roles.php
@@ -12,7 +12,7 @@
         <?php
         if (isset($_REQUEST['s']) && $search_str = esc_attr(wp_unslash(sanitize_text_field($_REQUEST['s'])))) {
             /* translators: %s: search keywords */
-            printf(' <span class="subtitle">' . esc_html__('Search results for &#8220;%s&#8221;', 'capability-manager-enhanced') . '</span>', esc_html($search_str));
+            printf(' <span class="subtitle">' . esc_html__('Search results for %s') . '</span>', '&#8220;' . esc_html($search_str) . '&#8221;');
         }
 
         //the roles table instance

--- a/includes/settings-ui.php
+++ b/includes/settings-ui.php
@@ -252,7 +252,7 @@ class Capabilities_Settings_UI {
                         </tr>
                     </table>
                 </fieldset>
-            <input type="submit" name="submit" id="submit" class="button button-primary" value="<?php esc_attr_e('Save Changes', 'capability-manager-enhanced');?>">
+            <input type="submit" name="submit" id="submit" class="button button-primary" value="<?php esc_attr_e('Save Changes');?>">
         </div><!-- .pp-column-left -->
         <div class="pp-column-right pp-capabilities-sidebar">
             <?php pp_capabilities_pro_sidebox(); ?>


### PR DESCRIPTION
If a string is already used by WP core, don't run it through translation functions with our plugin textdomain:

* So it will be translated for languages we haven't done
* So we don't have to translate it