### PR TITLE
fixes/#1260-Tooltip-goes-behind-the-sidebar-menu

### DIFF
--- a/common/css/admin-caps.css
+++ b/common/css/admin-caps.css
@@ -658,6 +658,11 @@ table.pp-capabilities-cb-key td.pp-cap-x {
     box-shadow: 0 1px 1px rgba(0, 0, 0, 0.04);
     background: #fff;
     font-size: initial;
+    position: initial;
+}
+
+.ppc-sidebar-panel .inside {
+  position: initial;
 }
 
 .ppc-sidebar-panel .postbox-header .hndle {


### PR DESCRIPTION
Tooltip goes behind the sidebar menu fix #1260