### PR TITLE
Fix/#1269-Registration-Redirects-feature-is-redirect-admin-when-new-users-are-added-from-admin-area

### DIFF
--- a/includes/functions.php
+++ b/includes/functions.php
@@ -279,6 +279,11 @@ add_action('init', 'ppc_test_user_init');
 * @param int $user_id The user ID.
 */
 function ppc_role_redirect_after_registration($user_id) {
+    // Skip redirection if the request is from the admin area.
+    if (is_admin()) {
+        return;
+    }
+    
     $user = get_user_by('ID', $user_id);
     
     if (pp_capabilities_feature_enabled('redirects') && is_object($user) && isset($user->roles) && is_array($user->roles)) {


### PR DESCRIPTION
Registration Redirects feature is redirect admin when new users are added from admin area fix #1269