### PR TITLE
fix/#1359-Admin-Notices-always-has-a-black-background

### DIFF
--- a/includes/admin-notices/assets/css/admin-notices.css
+++ b/includes/admin-notices/assets/css/admin-notices.css
@@ -18,10 +18,6 @@
     right: 0;
 }
 
-#wpadminbar .ppc-admin-notices-toolbar-item a.ab-item {
-    background: #2c3338;
-}
-
 .ppc-admin-notices-toolbar-item.hidden {
     display: none !important;
 }


### PR DESCRIPTION
 Admin Notices always has a black background fix #1359