### PR TITLE
fix/#1640-2-41-breaks-on-front-end-pp_capabilities_feature_enabled-undefined

### DIFF
--- a/includes/functions.php
+++ b/includes/functions.php
@@ -8,14 +8,6 @@
  *
  */
 
-//frontend features restrict instance
-require_once(dirname(__FILE__) . '/features/frontend-features/frontend-features-restrict.php');
-\PublishPress\Capabilities\PP_Capabilities_Frontend_Features_Restrict::instance();
-
-// Admin styles feature
-require_once(PUBLISHPRESS_CAPS_ABSPATH . '/includes/features/admin-styles/admin-styles.php');
-\PublishPress\Capabilities\PP_Capabilities_Admin_Styles::instance();
-
 /**
  * Sanitizes a string entry
  *
@@ -1636,4 +1628,12 @@ if (!function_exists('pp_capabilities_feature_enabled')) {
         return $feature_enabled;
     }
 }
+
+//frontend features restrict instance
+require_once(dirname(__FILE__) . '/features/frontend-features/frontend-features-restrict.php');
+\PublishPress\Capabilities\PP_Capabilities_Frontend_Features_Restrict::instance();
+
+// Admin styles feature
+require_once(PUBLISHPRESS_CAPS_ABSPATH . '/includes/features/admin-styles/admin-styles.php');
+\PublishPress\Capabilities\PP_Capabilities_Admin_Styles::instance();
 


### PR DESCRIPTION
2.41 breaks on front-end: “pp_capabilities_feature_enabled()” undefined. fix #1640 fix https://github.com/publishpress/publishpress-capabilities/issues/1641