### PR TITLE
Update .env.example to prompt for GitHub access token

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -9,7 +9,7 @@ PLUGIN_SLUG="capsman-enhanced"
 # -----------------------------------------------------------------------------
 # Git / GitHub (optional; set token for releases/API; leave name/email empty to be prompted)
 # -----------------------------------------------------------------------------
-GITHUB_ACCESS_TOKEN="ghp_0000000000000000000000000000000000000000"
+GITHUB_ACCESS_TOKEN="replace-with-github-token"
 GIT_USER_NAME=""
 GIT_USER_EMAIL=""
 


### PR DESCRIPTION
The dummy token starting with `ghp_` can sometimes be flagged as a token leak, a false positive.