### PR TITLE
fix/#1689-Direct-SQL-autoload-update-after-update_option-can-desync-option-cache-behavior

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+[2.44.0] - [UNRELEASHED]
+
+- Fixed : Direct SQL autoload update after update_option can desync option cache behavior, #1689
+
 [2.43.0] - 22 April, 2026
 
 - Update : Change fonts family and font sizes in Admin Styles, #1589

--- a/includes/handler.php
+++ b/includes/handler.php
@@ -1,9 +1,9 @@
 <?php
 /*
  * PublishPress Capabilities [Free]
- * 
+ *
  * Process update operations from the Capabilities screen
- * 
+ *
  */
 
 class CapsmanHandler
@@ -20,12 +20,12 @@ class CapsmanHandler
 
 		require_once (dirname(CME_FILE) . '/includes/roles/roles-functions.php');
 	}
-	
+
 	function processAdminGeneral() {
 		global $wpdb, $wp_roles;
-		
+
 		check_admin_referer('capsman-general-manager');
-		
+
 		if ( empty ($_POST['caps']) ) {
 		    $_POST['caps'] = array();
 		}
@@ -56,7 +56,7 @@ class CapsmanHandler
 			if ( defined( 'MULTISITE' ) && MULTISITE ) {
 				( method_exists( $wp_roles, 'for_site' ) ) ? $wp_roles->for_site() : $wp_roles->reinit();
 			}
-			
+
 			if (!pp_capabilities_is_editable_role(sanitize_key($_POST['current']))) {
 				ak_admin_error(__('The selected role is not editable.', 'capability-manager-enhanced'));
 				return;
@@ -64,20 +64,18 @@ class CapsmanHandler
 
 			$level = (isset($_POST['level'])) ? (int) $_POST['level'] : 0;
 			$this->saveRoleCapabilities(sanitize_key($_POST['current']), array_map('boolval', $_POST['caps']), $level);
-			
+
 			if (defined( 'PRESSPERMIT_ACTIVE' ) && !empty($_POST['role'])) {  // log customized role caps for subsequent restoration
 				// for bbPress < 2.2, need to log customization of roles following bbPress activation
 				$plugins = ( function_exists( 'bbp_get_version' ) && version_compare( bbp_get_version(), '2.2', '<' ) ) ? array( 'bbpress.php' ) : array();	// back compat
 
 				if ( ! $customized_roles = get_option( 'pp_customized_roles' ) )
 					$customized_roles = array();
-				
+
 				$_role = sanitize_key($_POST['role']);
 
 				$customized_roles[$_role] = (object) array( 'caps' => array_map( 'boolval', $_POST['caps'] ), 'plugins' => $plugins );
-				update_option( 'pp_customized_roles', $customized_roles );
-				
-				$wpdb->query( "UPDATE $wpdb->options SET autoload = 'no' WHERE option_name = 'pp_customized_roles'" );
+				update_option( 'pp_customized_roles', $customized_roles, false );
 			}
 		// Create New Capability and adds it to current role.
 		} elseif (!empty($_POST['AddCap']) && !empty($_POST['current']) && !empty($_POST['capability-name'])) {
@@ -100,14 +98,12 @@ class CapsmanHandler
 
 				// for bbPress < 2.2, need to log customization of roles following bbPress activation
 				$plugins = ( function_exists( 'bbp_get_version' ) && version_compare( bbp_get_version(), '2.2', '<' ) ) ? array( 'bbpress.php' ) : array();	// back compat
-				
+
 				if ( ! $customized_roles = get_option( 'pp_customized_roles' ) )
 					$customized_roles = array();
 
 				$customized_roles[sanitize_key($_POST['role'])] = (object) array( 'caps' => array_merge( $role->capabilities, array( $newname['name'] => 1 ) ), 'plugins' => $plugins );
-				update_option( 'pp_customized_roles', $customized_roles );
-				
-				$wpdb->query( "UPDATE $wpdb->options SET autoload = 'no' WHERE option_name = 'pp_customized_roles'" );
+				update_option( 'pp_customized_roles', $customized_roles, false );
 
 				$redirect_role = (!empty($_POST['role'])) ? sanitize_key($_POST['role']) : '';
 
@@ -119,7 +115,7 @@ class CapsmanHandler
 					ak_admin_notify(__('Incorrect capability name.', 'capability-manager-enhanced'));
 				});
 			}
-			
+
 		} elseif ( ! empty($_POST['update_filtered_types']) || ! empty($_POST['update_filtered_taxonomies']) || ! empty($_POST['update_detailed_taxonomies']) ) {
 				ak_admin_notify(__('Type / Taxonomy settings saved.', 'capability-manager-enhanced'));
 		} else {
@@ -134,14 +130,14 @@ class CapsmanHandler
 				$pp_only[]= $newrole;
 
 				pp_capabilities_update_permissions_option('supplemental_role_defs', $pp_only);
-				
+
 				_cme_pp_default_pattern_role( $newrole );
 				pp_refresh_options();
 			}
 		}
 	}
 
-	
+
 	/**
 	 * Creates a new role/capability name from user input name.
 	 * Name rules are:
@@ -220,10 +216,10 @@ class CapsmanHandler
 
 		// workaround to ensure db storage of customizations to bbp dynamic roles
 		$role->name = $role_name;
-		
+
 		$stored_role_caps = ( ! empty($role->capabilities) && is_array($role->capabilities) ) ? array_intersect( $role->capabilities, array(true, 1) ) : array();
 		$stored_negative_role_caps = ( ! empty($role->capabilities) && is_array($role->capabilities) ) ? array_intersect( $role->capabilities, array(false) ) : array();
-		
+
 		$old_caps = array_intersect_key( $stored_role_caps, $this->cm->capabilities);
 		$new_caps = ( is_array($caps) ) ? array_map('boolval', $caps) : array();
 		$new_caps = array_merge($new_caps, ak_level2caps($level));
@@ -237,9 +233,9 @@ class CapsmanHandler
 			if ( $new_caps[$cap_name] != $old_caps[$cap_name] )
 				$changed_caps[$cap_name] = $cap_val;
 		}
-		
+
 		$add_caps = array_merge( $add_caps, $changed_caps );
-		
+
 		if ( ! $is_administrator = current_user_can('administrator') ) {
 			unset($add_caps['manage_capabilities']);
 			unset($del_caps['manage_capabilities']);
@@ -249,12 +245,12 @@ class CapsmanHandler
 			unset($del_caps['manage_capabilities']);
 			ak_admin_error(__('You cannot remove Manage Capabilities from Administrators', 'capability-manager-enhanced'));
 		}
-		
+
 		// additional safeguard against removal of read capability
 		if ( isset( $del_caps['read'] ) && _cme_is_read_removal_blocked( $role_name ) ) {
 			unset( $del_caps['read'] );
 		}
-		
+
 		// Add new capabilities to role
 		foreach ( $add_caps as $cap => $grant ) {
 			if ( $is_administrator || current_user_can($cap) )
@@ -266,41 +262,41 @@ class CapsmanHandler
 			if ( $is_administrator || current_user_can($cap) )
 				$role->remove_cap($cap);
 		}
-		
+
 		$this->cm->log_db_roles();
-		
+
 		if (is_multisite() && is_super_admin() && is_main_site()) {
 			if ( ! $autocreate_roles = get_site_option( 'cme_autocreate_roles' ) )
 				$autocreate_roles = array();
-			
+
 			$this_role_autocreate = ! empty($_REQUEST['cme_autocreate_role']);
-			
+
 			if ( $this_role_autocreate && ! in_array( $role_name, $autocreate_roles ) ) {
 				$autocreate_roles []= $role_name;
 				update_site_option( 'cme_autocreate_roles', $autocreate_roles );
 			}
-			
+
 			if ( ! $this_role_autocreate && in_array( $role_name, $autocreate_roles ) ) {
 				$autocreate_roles = array_diff( $autocreate_roles, array( $role_name ) );
 				update_site_option( 'cme_autocreate_roles', $autocreate_roles );
 			}
-			
+
 			$do_role_sync = !empty($_REQUEST['cme_net_sync_role']);
 			$do_option_sync = !empty($_REQUEST['cme_net_sync_options']);
 
 			if ($do_role_sync || $do_option_sync) {
 				// loop through all sites on network, creating or updating role def
-		
+
 				global $wpdb, $wp_roles, $blog_id;
 				$blog_ids = $wpdb->get_col( "SELECT blog_id FROM $wpdb->blogs ORDER BY blog_id" );
-				$orig_blog_id = $blog_id;	
-		
+				$orig_blog_id = $blog_id;
+
 				if ($do_role_sync) {
 					$role_caption = $wp_roles->role_names[$role_name];
-					
+
 					$new_caps = ( is_array($caps) ) ? array_map('boolval', $caps) : array();
 					$new_caps = array_merge($new_caps, ak_level2caps($level) );
-					
+
 					$admin_role = $wp_roles->get_role('administrator');
 					$main_admin_caps = array_merge( $admin_role->capabilities, ak_level2caps(10) );
 				}
@@ -320,24 +316,24 @@ class CapsmanHandler
 					$sync_options['presspermit_supplemental_role_defs'] = get_option('presspermit_supplemental_role_defs');
 				}
 
-				foreach ( $blog_ids as $id ) {				
+				foreach ( $blog_ids as $id ) {
 					if ( is_main_site($id) )
 						continue;
-					
+
 					switch_to_blog( $id );
 
 					if ($do_role_sync) {
 						( method_exists( $wp_roles, 'for_site' ) ) ? $wp_roles->for_site() : $wp_roles->reinit();
-						
+
 						if ( $blog_role = $wp_roles->get_role( $role_name ) ) {
 							$stored_role_caps = ( ! empty($blog_role->capabilities) && is_array($blog_role->capabilities) ) ? array_intersect( $blog_role->capabilities, array(true, 1) ) : array();
-							
+
 							$old_caps = array_intersect_key( $stored_role_caps, $this->cm->capabilities);
 
 							// Find caps to add and remove
 							$add_caps = array_diff_key($new_caps, $old_caps);
 							$del_caps = array_intersect_key( array_diff_key($old_caps, $new_caps), $main_admin_caps );	// don't mess with caps that are totally unused on main site
-							
+
 							// Add new capabilities to role
 							foreach ( $add_caps as $cap => $grant ) {
 								$wp_roles->roles[$role_name]['capabilities'][$cap] = $grant;
@@ -360,10 +356,10 @@ class CapsmanHandler
 					foreach($sync_options as $option_name => $option_val) {
 						update_option($option_name, $option_val);
 					}
-					
+
 					restore_current_blog();
 				}
-				
+
 				( method_exists( $wp_roles, 'for_site' ) ) ? $wp_roles->for_site() : $wp_roles->reinit();
 			}
 		} // endif multisite installation with super admin editing a main site role


### PR DESCRIPTION
 Direct SQL autoload update after update_option can desync option cache behavior fix #1689