### PR TITLE
update/#1698-Limit-Admin-Notices-menu-capability-to-administrator-on-installation 

### DIFF
--- a/classes/pp-capabilities-installer.php
+++ b/classes/pp-capabilities-installer.php
@@ -167,7 +167,7 @@ class PP_Capabilities_Installer
 
     private static function addAdminNoticesCapabilities()
     {
-        $eligible_roles = ['administrator', 'editor'];
+        $eligible_roles = ['administrator'];
 
         foreach ($eligible_roles as $eligible_role) {
             $role = get_role($eligible_role);


### PR DESCRIPTION
Limit Admin Notices menu capability to administrator on installation fix #1698