### PR TITLE
Fix fatal error: load framework/lib/users.php before calling ak_get_roles() in cron context

### DIFF
--- a/includes/manager.php
+++ b/includes/manager.php
@@ -1322,6 +1322,11 @@ class CapabilityManager
 	function generateSysNames ()
 	{
 		$this->max_level = 10;
+
+		if ( ! function_exists( 'ak_get_roles' ) ) {
+			require_once dirname( CME_FILE ) . '/framework/lib/users.php';
+		}
+
 		$this->roles = ak_get_roles(true);
 		$caps = array();
 
@@ -1359,6 +1364,10 @@ class CapabilityManager
     		$names = array_map(array($this, '_capNamesCB'), $keys);
 
 	    	$this->capabilities = ( $keys ) ? array_combine($keys, $names) : array();
+
+		    if ( ! function_exists( 'ak_get_roles' ) ) {
+				require_once dirname( CME_FILE ) . '/framework/lib/users.php';
+			}
 
 		    $roles = ak_get_roles(true);
     		unset($roles['administrator']);


### PR DESCRIPTION
## Summary

- `ak_get_roles()` is defined in `framework/lib/users.php`, loaded only via `admin-load.php` on specific admin pages
- The `cme_network_sync_batch` WP-Cron event bootstraps `manager.php` directly, never passing through `admin-load.php`
- Result: fatal `Call to undefined function ak_get_roles()` at `manager.php:1325` whenever **Sync Role to All Sites** runs

## Fix

Added a `function_exists` guard at both call sites in `manager.php` (`generateSysNames()` and `generateNames()`), loading `framework/lib/users.php` on demand when `ak_get_roles()` is not already available. This is the most resilient approach — it catches any future code path that invokes these methods outside the normal admin bootstrap.

## Test plan

- [x] Trigger **Sync Role to All Sites** on a multisite install — confirm no fatal error
- [x] Verify normal admin capability management pages still work (no double-include issues)
- [x] Confirm `function_exists` guard is a no-op when file already loaded via normal admin path

🤖 Generated with [Claude Code](https://claude.com/claude-code)