### PR TITLE
fix/#1737-Multisite-role-sync-fails-on-localhost-with-headers-already-sent-(queued-message-+-blank-screen)

### DIFF
--- a/includes/handler.php
+++ b/includes/handler.php
@@ -307,7 +307,6 @@ class CapsmanHandler
 					$this->cm->network_sync_token = $token;
 				}
 
-				ak_admin_notify(__('Network sync has been queued and will continue in the background.', 'capability-manager-enhanced'));
 			}
 		} // endif multisite installation with super admin editing a main site role
 


### PR DESCRIPTION
 Multisite role sync fails on localhost with headers already sent (queued message + blank screen) fix #1737