### PR TITLE
feat(multisite): hide capabilities menu for subsite users

### DIFF
--- a/includes/admin-load.php
+++ b/includes/admin-load.php
@@ -48,6 +48,7 @@ class PP_Capabilities_Admin_UI {
 
             //Add role blocked nav menu indication
             add_action('wp_nav_menu_item_custom_fields', [$this, 'add_nav_menu_indicator'], 20, 5);
+            add_action('admin_init', [$this, 'blockSubsiteCapabilitiesAccess'], 1000);
         }
 
         add_filter('cme_publishpress_capabilities_capabilities', 'cme_publishpress_capabilities_capabilities');
@@ -538,6 +539,10 @@ class PP_Capabilities_Admin_UI {
 
         $capabilities_toplevel_page = $cap_page_slug;
 
+        if (!pp_capabilities_should_display_admin_menu()) {
+            return;
+        }
+
         if (!$cap_name) {
             return;
         }
@@ -570,6 +575,22 @@ class PP_Capabilities_Admin_UI {
 
     }
 
+
+    public function blockSubsiteCapabilitiesAccess() {
+        if (pp_capabilities_should_display_admin_menu()) {
+            return;
+        }
+
+        $sub_menu_pages = pp_capabilities_sub_menu_lists(true);
+        $capability_pages = array_map(function ($page) {
+            return $page['page'];
+        }, $sub_menu_pages);
+
+        if (!empty($_GET['page']) && in_array(sanitize_key($_GET['page']), $capability_pages, true)) {
+            wp_safe_redirect(admin_url());
+            exit;
+        }
+    }
 
     public function settingsUI() {
         wp_enqueue_script('pp-capabilities-chosen-js', plugin_dir_url(CME_FILE) . 'common/libs/chosen-v1.8.7/chosen.jquery.js', ['jquery'], PUBLISHPRESS_CAPS_VERSION);

--- a/includes/functions-admin.php
+++ b/includes/functions-admin.php
@@ -589,6 +589,35 @@ if (!function_exists('pp_capabilities_sub_menu_lists')) {
     }
 }
 
+if (!function_exists('pp_capabilities_should_display_admin_menu')) {
+    function pp_capabilities_should_display_admin_menu($user = null)
+    {
+        if (!is_multisite()) {
+            return true;
+        }
+
+        if (is_super_admin()) {
+            return true;
+        }
+
+        $current_user = null;
+        if (is_object($user) && isset($user->ID)) {
+            $current_user = $user;
+        } elseif (function_exists('wp_get_current_user')) {
+            $current_user = wp_get_current_user();
+        }
+
+        $should_display = true;
+        if (defined('PP_CAPABILITIES_HIDE_MENU_ON_SUBSITES') && PP_CAPABILITIES_HIDE_MENU_ON_SUBSITES) {
+            $should_display = false;
+        } else {
+            $should_display = (bool) apply_filters('pp_capabilities_display_admin_menu_on_subsite', true, $current_user);
+        }
+
+        return $should_display;
+    }
+}
+
 if (!function_exists('pp_capabilities_user_can_caps')) {
     function pp_capabilities_user_can_caps()
     {

--- a/includes/manager.php
+++ b/includes/manager.php
@@ -436,6 +436,10 @@ class CapabilityManager
 
         $capabilities_toplevel_page = $cap_page_slug;
 
+        if (!pp_capabilities_should_display_admin_menu()) {
+            return;
+        }
+
         if (!$cap_name) {
             return;
         }

--- a/tests/menu-restriction-test.php
+++ b/tests/menu-restriction-test.php
@@ -1,0 +1,48 @@
+<?php
+
+if (!defined('CME_FILE')) {
+    define('CME_FILE', dirname(__DIR__) . '/capsman-enhanced.php');
+}
+
+if (!defined('PP_CAPABILITIES_HIDE_MENU_ON_SUBSITES')) {
+    define('PP_CAPABILITIES_HIDE_MENU_ON_SUBSITES', true);
+}
+
+function is_multisite()
+{
+    return true;
+}
+
+function is_super_admin()
+{
+    return false;
+}
+
+function apply_filters($hook, $value, $user = null)
+{
+    if ($hook === 'pp_capabilities_display_admin_menu_on_subsite') {
+        return false;
+    }
+
+    return $value;
+}
+
+function current_user_can($capability)
+{
+    return false;
+}
+
+function wp_get_current_user()
+{
+    return null;
+}
+
+require_once dirname(__DIR__) . '/includes/functions-admin.php';
+
+$hidden = pp_capabilities_should_display_admin_menu();
+if ($hidden !== false) {
+    fwrite(STDERR, "Expected multisite subsite menus to be hidden when the constant is enabled.\n");
+    exit(1);
+}
+
+echo "Menu restriction test passed.\n";


### PR DESCRIPTION
To enable this behavior in a site or network, add one of the following:

- theme functions.php
```php
add_filter('pp_capabilities_display_admin_menu_on_subsite', '__return_false');
```

- Or define this in wp-config.php:
```php
define('PP_CAPABILITIES_HIDE_MENU_ON_SUBSITES', true);
```

This keeps the menu hidden for sub site users


fix https://github.com/publishpress/publishpress-capabilities/issues/1764