### PR TITLE
fix/translatable-search-and-chosen-messages

### DIFF
--- a/common/js/capabilities-search.js
+++ b/common/js/capabilities-search.js
@@ -183,10 +183,17 @@ jQuery(document).ready(function ($) {
 
         if (totalMatches > 0) {
             var tabsWithMatches = Object.keys(tabCounts).filter(key => tabCounts[key] > 0).length;
-            $summary.text('Found ' + totalMatches + ' match' + (totalMatches !== 1 ? 'es' : '') +
-                ' in ' + tabsWithMatches + ' tab' + (tabsWithMatches !== 1 ? 's' : ''));
+            var summaryKey;
+
+            if (totalMatches === 1) {
+                summaryKey = tabsWithMatches === 1 ? 'foundOneMatchOneTab' : 'foundOneMatchMultipleTabs';
+            } else {
+                summaryKey = tabsWithMatches === 1 ? 'foundMultipleMatchesOneTab' : 'foundMultipleMatchesMultipleTabs';
+            }
+
+            $summary.text(cmeAdmin[summaryKey].replace('%1$d', totalMatches).replace('%2$d', tabsWithMatches));
         } else {
-            $summary.text('No matches found for "' + searchTerm + '"');
+            $summary.text(cmeAdmin.noMatchesFoundFor.replace('%s', searchTerm));
         }
     }
 

--- a/common/js/profile.js
+++ b/common/js/profile.js
@@ -338,7 +338,8 @@ jQuery(function ($) {
 
     //init chosen.js
     $newField.chosen({
-      'width': '25em'
+      'width': '25em',
+      'no_results_text': ppCapabilitiesProfileData.chosen_no_results_text
     });
 
     /**

--- a/includes/admin-load.php
+++ b/includes/admin-load.php
@@ -378,6 +378,7 @@ class PP_Capabilities_Admin_UI {
                         'multi_roles'       => $multi_role ? 1 : 0,
                         'profile_page_title' => esc_html__('Page title', 'capability-manager-enhanced'),
                         'rankmath_title'    => esc_html__('Rank Math SEO', 'capability-manager-enhanced'),
+                        'chosen_no_results_text' => esc_html__('No results match', 'capability-manager-enhanced'),
                         'nonce'             => wp_create_nonce('ppc-profile-edit-action')
                     ]
                 );

--- a/includes/features/frontend-features/frontend-features-metaboxes.php
+++ b/includes/features/frontend-features/frontend-features-metaboxes.php
@@ -89,11 +89,11 @@ class PP_Capabilities_Frontend_Features_Metaboxes
                     class="chosen-cpt-select"
                     data-placeholder="<?php printf(esc_attr__('Select %1$s...', 'capability-manager-enhanced'), esc_html__($section_title)); ?>"
                     multiple>
-                    <?php 
+                    <?php
                     foreach ($section_elements as $section_id => $section_array) :
                         if (!$section_id) {
                             continue;
-                    } 
+                    }
                     ?>
                     <option value="<?php echo esc_attr($section_id); ?>" <?php selected(in_array($section_id, $post_features), true); ?>
                         >
@@ -122,7 +122,7 @@ class PP_Capabilities_Frontend_Features_Metaboxes
         if ((!is_multisite() || !is_super_admin()) && !current_user_can('administrator') && !current_user_can('manage_capabilities_frontend_features')) {
             return;
         }
-        
+
         if (empty($_POST['ppc-frontend-features-metabox-nonce'])
             || !wp_verify_nonce(sanitize_key($_POST['ppc-frontend-features-metabox-nonce']), 'ppc-frontend-features-metabox')) {
             return;
@@ -162,7 +162,8 @@ class PP_Capabilities_Frontend_Features_Metaboxes
                 $(function(){
                     if( $(".chosen-cpt-select").length ) {
                         $(".chosen-cpt-select").chosen({
-                            "width": "100%"
+                                                        "width": "100%",
+                                                        "no_results_text": <?php echo wp_json_encode(__("No results match", "capability-manager-enhanced")); ?>
                           });
                     }
                 });

--- a/includes/features/frontend-features/frontend-features-ui.php
+++ b/includes/features/frontend-features/frontend-features-ui.php
@@ -361,7 +361,8 @@ class PP_Capabilities_Frontend_Features_UI
                 $(function(){
                     if( $(".chosen-cpt-select").length ) {
                         $(".chosen-cpt-select").chosen({
-                            "width": "100%"
+                                                        "width": "100%",
+                                                        "no_results_text": <?php echo wp_json_encode(__("No results match", "capability-manager-enhanced")); ?>
                           });
                     }
                 });

--- a/includes/manager.php
+++ b/includes/manager.php
@@ -257,7 +257,12 @@ class CapabilityManager
 			'chkCaption' => __( 'Add or remove this capability from the WordPress role', 'capability-manager-enhanced' ),
 			'switchableCaption' => __( 'Add or remove capability from the role normally', 'capability-manager-enhanced' ),
 			'deleteWarning' => __( 'Are you sure you want to delete this item ?', 'capability-manager-enhanced' ),
-			'saveWarning'   => __( 'Add or clear custom item entry before saving changes.', 'capability-manager-enhanced' )
+			'saveWarning'   => __( 'Add or clear custom item entry before saving changes.', 'capability-manager-enhanced' ),
+			'foundOneMatchOneTab' => __( 'Found %1$d match in %2$d tab', 'capability-manager-enhanced' ),
+			'foundOneMatchMultipleTabs' => __( 'Found %1$d match in %2$d tabs', 'capability-manager-enhanced' ),
+			'foundMultipleMatchesOneTab' => __( 'Found %1$d matches in %2$d tab', 'capability-manager-enhanced' ),
+			'foundMultipleMatchesMultipleTabs' => __( 'Found %1$d matches in %2$d tabs', 'capability-manager-enhanced' ),
+			'noMatchesFoundFor' => __( 'No matches found for "%s"', 'capability-manager-enhanced' )
 			]
 		);
     }

--- a/includes/settings-ui.php
+++ b/includes/settings-ui.php
@@ -330,7 +330,8 @@ class Capabilities_Settings_UI {
             });
 
             $('.pp-capabilities-settings-chosen').chosen({
-                'width': '30em'
+                'width': '30em',
+                'no_results_text': '<?php echo esc_js(__('No results match', 'capability-manager-enhanced')); ?>'
             });
 
         });


### PR DESCRIPTION
- The string "No results match" of Chosen does not display translated fix #1761
- The string "No matches found for " is hard-coded and not translatable fix #1760