### PR TITLE
Add a per-user capabilities view

### DIFF
--- a/common/js/user-capabilities.js
+++ b/common/js/user-capabilities.js
@@ -1,0 +1,38 @@
+(function () {
+    'use strict';
+
+    function initGrantedCapabilitySearch() {
+        var search = document.getElementById('ppc-granted-capability-search');
+        var list = document.getElementById('ppc-granted-capability-list');
+        var noResults = document.getElementById('ppc-granted-capability-no-results');
+
+        if (!search || !list || !noResults) {
+            return;
+        }
+
+        var items = list.querySelectorAll('li[data-ppc-capability-search]');
+
+        search.addEventListener('input', function () {
+            var searchTerm = search.value.toLowerCase().trim();
+            var visibleCount = 0;
+
+            Array.prototype.forEach.call(items, function (item) {
+                var matches = !searchTerm || item.textContent.toLowerCase().indexOf(searchTerm) !== -1;
+
+                item.hidden = !matches;
+
+                if (matches) {
+                    visibleCount++;
+                }
+            });
+
+            noResults.hidden = !searchTerm || visibleCount > 0;
+        });
+    }
+
+    if ('loading' === document.readyState) {
+        document.addEventListener('DOMContentLoaded', initGrantedCapabilitySearch);
+    } else {
+        initGrantedCapabilitySearch();
+    }
+}());

--- a/includes/admin-load.php
+++ b/includes/admin-load.php
@@ -1268,6 +1268,10 @@ class PP_Capabilities_Admin_UI {
                 margin: 0;
             }
 
+            .ppc-user-capabilities-grid .postbox-header h2 {
+                margin-left: 12px;
+            }
+
             .ppc-user-cap-list {
                 columns: 2 220px;
                 column-gap: 24px;

--- a/includes/admin-load.php
+++ b/includes/admin-load.php
@@ -895,6 +895,220 @@ class PP_Capabilities_Admin_UI {
         );
     }
 
+    private function getPublishPressPermissionsEditUrl($user_id, $anchor = '')
+    {
+        $url = add_query_arg(
+            [
+                'page' => 'presspermit-edit-permissions',
+                'action' => 'edit',
+                'agent_id' => absint($user_id),
+                'agent_type' => 'user',
+            ],
+            admin_url('admin.php')
+        );
+
+        return $anchor ? $url . '#' . sanitize_key($anchor) : $url;
+    }
+
+    private function getPublishPressPermissionsRoleLabel($pp, $role_name)
+    {
+        $label = $role_name;
+
+        if (is_callable([$pp, 'admin'])) {
+            $pp_admin = $pp->admin();
+
+            if (is_object($pp_admin) && is_callable([$pp_admin, 'getRoleTitle'])) {
+                $label = $pp_admin->getRoleTitle(
+                    $role_name,
+                    [
+                        'include_warnings' => false,
+                        'echo' => false,
+                        'status_suffix' => true,
+                    ]
+                );
+            }
+        }
+
+        $label = wp_specialchars_decode(wp_strip_all_tags((string) $label), ENT_QUOTES);
+        $label = preg_replace('/\s+/u', ' ', str_replace("\xc2\xa0", ' ', $label));
+
+        return $label ? trim($label) : $role_name;
+    }
+
+    private function getPublishPressPermissionsExceptionLabel($pp, $row)
+    {
+        $operation = !empty($row->operation) ? sanitize_key($row->operation) : '';
+        $modification = !empty($row->mod_type) ? sanitize_key($row->mod_type) : '';
+        $for_item_source = !empty($row->for_item_source) ? sanitize_key($row->for_item_source) : '';
+        $for_item_type = !empty($row->for_item_type) ? sanitize_key($row->for_item_type) : '';
+        $via_item_source = !empty($row->via_item_source) ? sanitize_key($row->via_item_source) : '';
+        $via_item_type = !empty($row->via_item_type) ? sanitize_key($row->via_item_type) : '';
+        $for_item_status = !empty($row->for_item_status) ? sanitize_text_field($row->for_item_status) : '';
+        $assign_for = !empty($row->assign_for) ? sanitize_key($row->assign_for) : '';
+
+        $operation_label = $operation
+            ? ucwords(str_replace('_', ' ', $operation))
+            : __('Permission', 'capability-manager-enhanced');
+        $modification_labels = [
+            'additional' => __('Enabled', 'capability-manager-enhanced'),
+            'exclude' => __('Blocked', 'capability-manager-enhanced'),
+            'include' => __('Limited', 'capability-manager-enhanced'),
+        ];
+        $modification_label = !empty($modification_labels[$modification])
+            ? $modification_labels[$modification]
+            : ucwords(str_replace('_', ' ', $modification));
+
+        if ($operation && is_callable([$pp, 'admin'])) {
+            $pp_admin = $pp->admin();
+
+            if (is_object($pp_admin) && is_callable([$pp_admin, 'getOperationObject'])) {
+                $operation_object = $pp_admin->getOperationObject($operation, $for_item_type);
+
+                if (is_object($operation_object) && !empty($operation_object->label)) {
+                    $operation_label = wp_strip_all_tags((string) $operation_object->label);
+                }
+            }
+        }
+
+        $type_label = $for_item_type ? $for_item_type : __('All content', 'capability-manager-enhanced');
+
+        if ($for_item_source && is_callable([$pp, 'getTypeObject']) && $for_item_type) {
+            $type_object = $pp->getTypeObject($for_item_source, $for_item_type);
+
+            if (is_object($type_object) && !empty($type_object->labels->name)) {
+                $type_label = $type_object->labels->name;
+            } elseif (is_object($type_object) && !empty($type_object->labels->singular_name)) {
+                $type_label = $type_object->labels->singular_name;
+            }
+        }
+
+        $item_label = '';
+        $item_id = !empty($row->item_id) ? absint($row->item_id) : 0;
+
+        if ($item_id && 'post' === $via_item_source) {
+            $item_label = get_the_title($item_id);
+        } elseif ($item_id && 'term' === $via_item_source && $via_item_type) {
+            $term = get_term_by('term_taxonomy_id', $item_id, $via_item_type);
+            $item_label = ($term && !is_wp_error($term)) ? $term->name : '';
+        }
+
+        if ($item_id) {
+            $item_label = $item_label ? $item_label : sprintf(__('Item #%d', 'capability-manager-enhanced'), $item_id);
+            $scope_label = sprintf(
+                __('%1$s: %2$s', 'capability-manager-enhanced'),
+                $type_label,
+                $item_label
+            );
+        } else {
+            $scope_label = sprintf(
+                __('%s: all items', 'capability-manager-enhanced'),
+                $type_label
+            );
+        }
+
+        if ($for_item_status) {
+            $scope_label .= ' (' . ucwords(str_replace(['_', ':'], [' ', ':'], $for_item_status)) . ')';
+        }
+
+        if ($assign_for && 'item' !== $assign_for) {
+            $scope_label .= ' (' . ucwords(str_replace('_', ' ', $assign_for)) . ')';
+        }
+
+        return [
+            'operation' => $operation_label,
+            'modification' => $modification_label,
+            'scope' => $scope_label,
+        ];
+    }
+
+    private function getPublishPressPermissionsUserData($user_id)
+    {
+        $data = [
+            'available' => false,
+            'roles' => [],
+            'roles_total' => 0,
+            'exceptions' => [],
+            'exceptions_total' => 0,
+            'roles_edit_url' => '',
+            'exceptions_edit_url' => '',
+        ];
+
+        if (!defined('PRESSPERMIT_ACTIVE') || !PRESSPERMIT_ACTIVE || !function_exists('presspermit')) {
+            return $data;
+        }
+
+        $pp = presspermit();
+
+        if (!is_object($pp) || !method_exists($pp, 'getRoles') || !method_exists($pp, 'getExceptions')) {
+            return $data;
+        }
+
+        $data['available'] = true;
+        $role_assignments = $pp->getRoles(absint($user_id), 'user');
+
+        foreach (array_keys((array) $role_assignments) as $role_name) {
+            $role_name = sanitize_text_field((string) $role_name);
+
+            if ('' !== $role_name) {
+                $data['roles'][] = [
+                    'slug' => $role_name,
+                    'label' => $this->getPublishPressPermissionsRoleLabel($pp, $role_name),
+                ];
+            }
+        }
+
+        usort($data['roles'], static function ($left, $right) {
+            return strnatcasecmp($left['label'], $right['label']);
+        });
+        $data['roles_total'] = count($data['roles']);
+
+        $exceptions = $pp->getExceptions(
+            [
+                'agent_type' => 'user',
+                'agent_id' => absint($user_id),
+                'assign_for' => '',
+                'post_types' => true,
+                'taxonomies' => true,
+                'return_raw_results' => true,
+            ]
+        );
+
+        if (is_array($exceptions)) {
+            foreach (array_slice($exceptions, 0, 50) as $exception) {
+                if (is_array($exception)) {
+                    $exception = (object) $exception;
+                }
+
+                if (!is_object($exception) || empty($exception->operation)) {
+                    continue;
+                }
+
+                $data['exceptions'][] = $this->getPublishPressPermissionsExceptionLabel($pp, $exception);
+            }
+
+            $data['exceptions_total'] = count($exceptions);
+        }
+
+        $can_edit_permissions = current_user_can('pp_administer_content')
+            && current_user_can('list_users')
+            && (is_multisite() || current_user_can('edit_user', absint($user_id)));
+
+        if ($can_edit_permissions && is_callable([$pp, 'admin'])) {
+            $pp_admin = $pp->admin();
+
+            if (is_object($pp_admin) && is_callable([$pp_admin, 'bulkRolesEnabled'])) {
+                $can_edit_permissions = (bool) $pp_admin->bulkRolesEnabled();
+            }
+        }
+
+        if ($can_edit_permissions) {
+            $data['roles_edit_url'] = $this->getPublishPressPermissionsEditUrl($user_id, 'pp_current_roles_1');
+            $data['exceptions_edit_url'] = $this->getPublishPressPermissionsEditUrl($user_id, 'pp_current_exceptions_1');
+        }
+
+        return $data;
+    }
+
     private function getUserCapabilitiesPageData($user)
     {
         $user->get_role_caps();
@@ -952,6 +1166,7 @@ class PP_Capabilities_Admin_UI {
             'direct_denied_caps' => array_keys(array_filter($direct_capabilities, static function ($granted) {
                 return !$granted;
             })),
+            'publishpress_permissions' => $this->getPublishPressPermissionsUserData($user->ID),
         ];
     }
 
@@ -1075,6 +1290,38 @@ class PP_Capabilities_Admin_UI {
             .ppc-user-cap-note {
                 color: #50575e;
             }
+
+            .ppc-user-permissions-list {
+                margin: 0;
+            }
+
+            .ppc-user-permissions-list li {
+                border-bottom: 1px solid #dcdcde;
+                margin: 0;
+                padding: 8px 0;
+            }
+
+            .ppc-user-permissions-list li:last-child {
+                border-bottom: 0;
+            }
+
+            .ppc-user-permissions-scope {
+                color: #50575e;
+                display: block;
+                margin-top: 2px;
+            }
+
+            .ppc-user-permissions-actions {
+                display: flex;
+                flex-wrap: wrap;
+                gap: 8px;
+                margin: 12px 0 0;
+            }
+
+            .ppc-user-permissions-scroll {
+                max-height: 280px;
+                overflow-y: auto;
+            }
         </style>
         <?php
     }
@@ -1110,6 +1357,7 @@ class PP_Capabilities_Admin_UI {
         $effective_denied_caps = $page_data['effective_denied_caps'];
         $direct_granted_caps = $page_data['direct_granted_caps'];
         $direct_denied_caps = $page_data['direct_denied_caps'];
+        $publishpress_permissions = $page_data['publishpress_permissions'];
         $back_url = admin_url('users.php');
 
         include dirname(CME_FILE) . '/includes/user-capabilities-view.php';

--- a/includes/admin-load.php
+++ b/includes/admin-load.php
@@ -332,6 +332,20 @@ class PP_Capabilities_Admin_UI {
             ]
         );
 
+        if (function_exists('get_current_screen')) {
+            $screen = get_current_screen();
+
+            if ($screen && 'users_page_pp-capabilities-user-view' === $screen->id) {
+                wp_enqueue_script(
+                    'pp-capabilities-user-capabilities-js',
+                    plugin_dir_url(CME_FILE) . 'common/js/user-capabilities.js',
+                    [],
+                    PUBLISHPRESS_CAPS_VERSION,
+                    true
+                );
+            }
+        }
+
         if (function_exists('get_current_screen') && (!defined('PUBLISHPRESS_VERSION') || empty($publishpress) || empty($publishpress->modules) || empty($publishpress->modules->roles))) {
             $screen = get_current_screen();
 
@@ -1293,6 +1307,20 @@ class PP_Capabilities_Admin_UI {
 
             .ppc-user-cap-note {
                 color: #50575e;
+            }
+
+            .ppc-user-capability-search {
+                margin-bottom: 4px;
+                max-width: 360px;
+                width: 100%;
+            }
+
+            .ppc-user-capability-search-description {
+                margin-bottom: 12px;
+            }
+
+            .ppc-user-capability-search-no-results {
+                margin: 12px 0 0;
             }
 
             .ppc-user-permissions-list {

--- a/includes/admin-load.php
+++ b/includes/admin-load.php
@@ -50,6 +50,13 @@ class PP_Capabilities_Admin_UI {
             );
             add_action('admin_init', [$this, 'manage_installation'], 2000);
 
+            // Add user capabilities view from the Users screen.
+            add_action('admin_menu', [$this, 'registerUserCapabilitiesPage'], 19);
+            add_action('show_user_profile', [$this, 'addUserCapabilitiesProfileAction']);
+            add_action('edit_user_profile', [$this, 'addUserCapabilitiesProfileAction']);
+            add_filter('user_row_actions', [$this, 'addUserCapabilitiesRowAction'], 11, 2);
+            add_action('admin_head-users_page_pp-capabilities-user-view', [$this, 'outputUserCapabilitiesPageStyles']);
+
             //Add role blocked nav menu indication
             add_action('wp_nav_menu_item_custom_fields', [$this, 'add_nav_menu_indicator'], 20, 5);
             add_action('admin_init', [$this, 'blockSubsiteCapabilitiesAccess'], 1000);
@@ -859,6 +866,254 @@ class PP_Capabilities_Admin_UI {
 
         <?php
 	}
+
+    private function canViewUserCapabilities($user)
+    {
+        if (!pp_capabilities_feature_enabled('capabilities') || empty($user) || empty($user->ID)) {
+            return false;
+        }
+
+        if (!current_user_can('edit_user', $user->ID)) {
+            return false;
+        }
+
+        if (is_multisite() && is_super_admin()) {
+            return true;
+        }
+
+        return current_user_can('administrator') || current_user_can('manage_capabilities');
+    }
+
+    private function getUserCapabilitiesPageUrl($user_id)
+    {
+        return add_query_arg(
+            [
+                'page' => 'pp-capabilities-user-view',
+                'user_id' => absint($user_id),
+            ],
+            admin_url('users.php')
+        );
+    }
+
+    private function getUserCapabilitiesPageData($user)
+    {
+        $user->get_role_caps();
+
+        $role_names = wp_roles()->get_names();
+        $assigned_roles = [];
+
+        foreach ((array) $user->roles as $role_name) {
+            $role_name = sanitize_key($role_name);
+
+            if ('' === $role_name) {
+                continue;
+            }
+
+            $assigned_roles[] = [
+                'slug' => $role_name,
+                'label' => !empty($role_names[$role_name]) ? translate_user_role($role_names[$role_name]) : $role_name,
+                'url' => pp_capabilities_is_editable_role($role_name)
+                    ? admin_url('admin.php?page=pp-capabilities&role=' . $role_name)
+                    : '',
+            ];
+        }
+
+        $effective_capabilities = [];
+        foreach ((array) $user->allcaps as $cap_name => $granted) {
+            $cap_name = sanitize_text_field((string) $cap_name);
+
+            if ('' === $cap_name || in_array($cap_name, $user->roles, true)) {
+                continue;
+            }
+
+            $effective_capabilities[$cap_name] = (bool) $granted;
+        }
+        uksort($effective_capabilities, 'strnatcasecmp');
+
+        $direct_capabilities = [];
+        foreach ((array) $user->caps as $cap_name => $granted) {
+            $cap_name = sanitize_text_field((string) $cap_name);
+
+            if ('' === $cap_name || in_array($cap_name, $user->roles, true)) {
+                continue;
+            }
+
+            $direct_capabilities[$cap_name] = (bool) $granted;
+        }
+        uksort($direct_capabilities, 'strnatcasecmp');
+
+        return [
+            'assigned_roles' => $assigned_roles,
+            'effective_granted_caps' => array_keys(array_filter($effective_capabilities)),
+            'effective_denied_caps' => array_keys(array_filter($effective_capabilities, static function ($granted) {
+                return !$granted;
+            })),
+            'direct_granted_caps' => array_keys(array_filter($direct_capabilities)),
+            'direct_denied_caps' => array_keys(array_filter($direct_capabilities, static function ($granted) {
+                return !$granted;
+            })),
+        ];
+    }
+
+    public function registerUserCapabilitiesPage()
+    {
+        if (!pp_capabilities_feature_enabled('capabilities')) {
+            return;
+        }
+
+        add_users_page(
+            __('User Capabilities', 'capability-manager-enhanced'),
+            __('User Capabilities', 'capability-manager-enhanced'),
+            'read',
+            'pp-capabilities-user-view',
+            [$this, 'userCapabilitiesPage']
+        );
+
+        remove_submenu_page('users.php', 'pp-capabilities-user-view');
+    }
+
+    public function addUserCapabilitiesRowAction($actions, $user)
+    {
+        if (!$this->canViewUserCapabilities($user)) {
+            return $actions;
+        }
+
+        $actions['pp_capabilities_view_user'] = sprintf(
+            '<a href="%s">%s</a>',
+            esc_url($this->getUserCapabilitiesPageUrl($user->ID)),
+            esc_html__('Capabilities', 'capability-manager-enhanced')
+        );
+
+        return $actions;
+    }
+
+    public function addUserCapabilitiesProfileAction($user)
+    {
+        if (!$this->canViewUserCapabilities($user)) {
+            return;
+        }
+        ?>
+        <tr class="user-capabilities-view-wrap">
+            <th scope="row"><?php esc_html_e('Capabilities', 'capability-manager-enhanced'); ?></th>
+            <td>
+                <a href="<?php echo esc_url($this->getUserCapabilitiesPageUrl($user->ID)); ?>" class="button">
+                    <?php esc_html_e('View Capabilities', 'capability-manager-enhanced'); ?>
+                </a>
+            </td>
+        </tr>
+        <?php
+    }
+
+    public function outputUserCapabilitiesPageStyles()
+    {
+        ?>
+        <style id="pp-capabilities-user-capabilities-page">
+            .ppc-user-capabilities-header {
+                display: flex;
+                align-items: center;
+                gap: 12px;
+                margin-bottom: 8px;
+            }
+
+            .ppc-user-capabilities-meta {
+                display: grid;
+                grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+                gap: 12px;
+                margin: 18px 0 0;
+            }
+
+            .ppc-user-capabilities-meta-item {
+                background: #fff;
+                border: 1px solid #dcdcde;
+                border-radius: 4px;
+                padding: 12px 14px;
+            }
+
+            .ppc-user-capabilities-meta-item dt {
+                font-weight: 600;
+                margin-bottom: 4px;
+            }
+
+            .ppc-user-capabilities-meta-item dd {
+                margin: 0;
+            }
+
+            .ppc-user-capabilities-grid {
+                display: grid;
+                grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+                gap: 16px;
+                margin-top: 18px;
+            }
+
+            .ppc-user-capabilities-grid .inside {
+                padding: 16px;
+            }
+
+            .ppc-user-capabilities-grid .postbox {
+                margin: 0;
+            }
+
+            .ppc-user-cap-list {
+                columns: 2 220px;
+                column-gap: 24px;
+                margin: 0;
+            }
+
+            .ppc-user-cap-list li {
+                break-inside: avoid;
+                margin-bottom: 8px;
+            }
+
+            .ppc-user-cap-list code {
+                font-size: 12px;
+            }
+
+            .ppc-user-cap-section-title {
+                margin: 0 0 8px;
+            }
+
+            .ppc-user-cap-note {
+                color: #50575e;
+            }
+        </style>
+        <?php
+    }
+
+    public function userCapabilitiesPage()
+    {
+        if (!pp_capabilities_feature_enabled('capabilities')) {
+            wp_die(
+                esc_html__('You do not have permission to view user capabilities.', 'capability-manager-enhanced'),
+                '',
+                ['response' => 403]
+            );
+        }
+
+        $user_id = !empty($_GET['user_id']) ? absint($_GET['user_id']) : 0;
+        $selected_user = $user_id ? get_user_by('id', $user_id) : false;
+
+        if (!$selected_user || empty($selected_user->ID)) {
+            wp_die(esc_html__('Unable to retrieve user data.', 'capability-manager-enhanced'));
+        }
+
+        if (!$this->canViewUserCapabilities($selected_user)) {
+            wp_die(
+                esc_html__('You do not have permission to view user capabilities.', 'capability-manager-enhanced'),
+                '',
+                ['response' => 403]
+            );
+        }
+
+        $page_data = $this->getUserCapabilitiesPageData($selected_user);
+        $assigned_roles = $page_data['assigned_roles'];
+        $effective_granted_caps = $page_data['effective_granted_caps'];
+        $effective_denied_caps = $page_data['effective_denied_caps'];
+        $direct_granted_caps = $page_data['direct_granted_caps'];
+        $direct_denied_caps = $page_data['direct_denied_caps'];
+        $back_url = admin_url('users.php');
+
+        include dirname(CME_FILE) . '/includes/user-capabilities-view.php';
+    }
 
     /**
     * Redirect user on plugin activation

--- a/includes/user-capabilities-view.php
+++ b/includes/user-capabilities-view.php
@@ -136,5 +136,88 @@ if (!defined('ABSPATH')) {
                 <?php endif; ?>
             </div>
         </div>
+
+        <?php if (!empty($publishpress_permissions['available'])) : ?>
+            <div class="postbox">
+                <div class="postbox-header">
+                    <h2><?php esc_html_e('PublishPress Permissions', 'capability-manager-enhanced'); ?></h2>
+                </div>
+                <div class="inside">
+                    <p class="ppc-user-cap-note">
+                        <?php esc_html_e('Direct Permissions settings for this user. These are separate from WordPress role capabilities.', 'capability-manager-enhanced'); ?>
+                    </p>
+
+                    <h3 class="ppc-user-cap-section-title">
+                        <?php
+                        printf(
+                            esc_html__('Extra Roles (%d)', 'capability-manager-enhanced'),
+                            (int) $publishpress_permissions['roles_total']
+                        );
+                        ?>
+                    </h3>
+
+                    <?php if (empty($publishpress_permissions['roles'])) : ?>
+                        <p><?php esc_html_e('This user has no direct extra roles.', 'capability-manager-enhanced'); ?></p>
+                    <?php else : ?>
+                        <ul class="ppc-user-permissions-list ppc-user-permissions-scroll">
+                            <?php foreach ($publishpress_permissions['roles'] as $role_data) : ?>
+                                <li>
+                                    <?php echo esc_html($role_data['label']); ?>
+                                    <code><?php echo esc_html($role_data['slug']); ?></code>
+                                </li>
+                            <?php endforeach; ?>
+                        </ul>
+                    <?php endif; ?>
+
+                    <h3 class="ppc-user-cap-section-title">
+                        <?php
+                        printf(
+                            esc_html__('Specific Permissions (%d)', 'capability-manager-enhanced'),
+                            (int) $publishpress_permissions['exceptions_total']
+                        );
+                        ?>
+                    </h3>
+
+                    <?php if (empty($publishpress_permissions['exceptions'])) : ?>
+                        <p><?php esc_html_e('This user has no direct specific permissions.', 'capability-manager-enhanced'); ?></p>
+                    <?php else : ?>
+                        <ul class="ppc-user-permissions-list ppc-user-permissions-scroll">
+                            <?php foreach ($publishpress_permissions['exceptions'] as $exception) : ?>
+                                <li>
+                                    <strong><?php echo esc_html($exception['operation']); ?></strong>
+                                    <?php echo esc_html($exception['modification']); ?>
+                                    <span class="ppc-user-permissions-scope"><?php echo esc_html($exception['scope']); ?></span>
+                                </li>
+                            <?php endforeach; ?>
+                        </ul>
+                        <?php if ($publishpress_permissions['exceptions_total'] > count($publishpress_permissions['exceptions'])) : ?>
+                            <p class="ppc-user-cap-note">
+                                <?php
+                                printf(
+                                    esc_html__('Showing the first 50 of %d permissions. Use the Permissions editor to view the full list.', 'capability-manager-enhanced'),
+                                    (int) $publishpress_permissions['exceptions_total']
+                                );
+                                ?>
+                            </p>
+                        <?php endif; ?>
+                    <?php endif; ?>
+
+                    <?php if (!empty($publishpress_permissions['roles_edit_url']) || !empty($publishpress_permissions['exceptions_edit_url'])) : ?>
+                        <div class="ppc-user-permissions-actions">
+                            <?php if (!empty($publishpress_permissions['roles_edit_url'])) : ?>
+                                <a href="<?php echo esc_url($publishpress_permissions['roles_edit_url']); ?>" class="button">
+                                    <?php esc_html_e('Edit Extra Roles', 'capability-manager-enhanced'); ?>
+                                </a>
+                            <?php endif; ?>
+                            <?php if (!empty($publishpress_permissions['exceptions_edit_url'])) : ?>
+                                <a href="<?php echo esc_url($publishpress_permissions['exceptions_edit_url']); ?>" class="button">
+                                    <?php esc_html_e('Edit Specific Permissions', 'capability-manager-enhanced'); ?>
+                                </a>
+                            <?php endif; ?>
+                        </div>
+                    <?php endif; ?>
+                </div>
+            </div>
+        <?php endif; ?>
     </div>
 </div>

--- a/includes/user-capabilities-view.php
+++ b/includes/user-capabilities-view.php
@@ -1,0 +1,140 @@
+<?php
+/**
+ * PublishPress Capabilities [Free]
+ *
+ * UI output for per-user capabilities view.
+ */
+
+if (!defined('ABSPATH')) {
+    exit;
+}
+?>
+<div class="wrap publishpress-caps-manage pressshack-admin-wrapper ppc-user-capabilities-wrap">
+    <div class="ppc-user-capabilities-header">
+        <h1><?php esc_html_e('User Capabilities', 'capability-manager-enhanced'); ?></h1>
+        <a href="<?php echo esc_url($back_url); ?>" class="page-title-action"><?php esc_html_e('Back to Users', 'capability-manager-enhanced'); ?></a>
+    </div>
+
+    <p>
+        <?php
+        printf(
+            esc_html__('Viewing effective capabilities for %s.', 'capability-manager-enhanced'),
+            esc_html($selected_user->display_name)
+        );
+        ?>
+    </p>
+
+    <dl class="ppc-user-capabilities-meta">
+        <div class="ppc-user-capabilities-meta-item">
+            <dt><?php esc_html_e('Username', 'capability-manager-enhanced'); ?></dt>
+            <dd><code><?php echo esc_html($selected_user->user_login); ?></code></dd>
+        </div>
+
+        <?php if (!empty($selected_user->user_email)) : ?>
+            <div class="ppc-user-capabilities-meta-item">
+                <dt><?php esc_html_e('Email', 'capability-manager-enhanced'); ?></dt>
+                <dd><?php echo esc_html($selected_user->user_email); ?></dd>
+            </div>
+        <?php endif; ?>
+
+        <div class="ppc-user-capabilities-meta-item">
+            <dt><?php esc_html_e('Assigned Roles', 'capability-manager-enhanced'); ?></dt>
+            <dd><?php echo (int) count($assigned_roles); ?></dd>
+        </div>
+
+        <div class="ppc-user-capabilities-meta-item">
+            <dt><?php esc_html_e('Granted Capabilities', 'capability-manager-enhanced'); ?></dt>
+            <dd><?php echo (int) count($effective_granted_caps); ?></dd>
+        </div>
+    </dl>
+
+    <div class="ppc-user-capabilities-grid">
+        <div class="postbox">
+            <div class="postbox-header">
+                <h2><?php esc_html_e('Assigned Roles', 'capability-manager-enhanced'); ?></h2>
+            </div>
+            <div class="inside">
+                <?php if (empty($assigned_roles)) : ?>
+                    <p><?php esc_html_e('This user has no assigned roles.', 'capability-manager-enhanced'); ?></p>
+                <?php else : ?>
+                    <ul>
+                        <?php foreach ($assigned_roles as $role_data) : ?>
+                            <li>
+                                <?php if (!empty($role_data['url'])) : ?>
+                                    <a href="<?php echo esc_url($role_data['url']); ?>"><?php echo esc_html($role_data['label']); ?></a>
+                                <?php else : ?>
+                                    <?php echo esc_html($role_data['label']); ?>
+                                <?php endif; ?>
+                                <code><?php echo esc_html($role_data['slug']); ?></code>
+                            </li>
+                        <?php endforeach; ?>
+                    </ul>
+                <?php endif; ?>
+            </div>
+        </div>
+
+        <div class="postbox">
+            <div class="postbox-header">
+                <h2><?php printf(esc_html__('Granted Capabilities (%d)', 'capability-manager-enhanced'), (int) count($effective_granted_caps)); ?></h2>
+            </div>
+            <div class="inside">
+                <p class="ppc-user-cap-note"><?php esc_html_e('These are the capabilities WordPress resolves for this user after role assignments and any direct overrides.', 'capability-manager-enhanced'); ?></p>
+                <?php if (empty($effective_granted_caps)) : ?>
+                    <p><?php esc_html_e('This user has no granted capabilities.', 'capability-manager-enhanced'); ?></p>
+                <?php else : ?>
+                    <ul class="ppc-user-cap-list">
+                        <?php foreach ($effective_granted_caps as $capability) : ?>
+                            <li><code><?php echo esc_html($capability); ?></code></li>
+                        <?php endforeach; ?>
+                    </ul>
+                <?php endif; ?>
+            </div>
+        </div>
+
+        <?php if (!empty($effective_denied_caps)) : ?>
+            <div class="postbox">
+                <div class="postbox-header">
+                    <h2><?php printf(esc_html__('Denied Capabilities (%d)', 'capability-manager-enhanced'), (int) count($effective_denied_caps)); ?></h2>
+                </div>
+                <div class="inside">
+                    <ul class="ppc-user-cap-list">
+                        <?php foreach ($effective_denied_caps as $capability) : ?>
+                            <li><code><?php echo esc_html($capability); ?></code></li>
+                        <?php endforeach; ?>
+                    </ul>
+                </div>
+            </div>
+        <?php endif; ?>
+
+        <div class="postbox">
+            <div class="postbox-header">
+                <h2><?php esc_html_e('Direct User Overrides', 'capability-manager-enhanced'); ?></h2>
+            </div>
+            <div class="inside">
+                <p class="ppc-user-cap-note"><?php esc_html_e('These entries are stored directly on the user account instead of coming from a role.', 'capability-manager-enhanced'); ?></p>
+
+                <?php if (empty($direct_granted_caps) && empty($direct_denied_caps)) : ?>
+                    <p><?php esc_html_e('This user has no direct capability overrides.', 'capability-manager-enhanced'); ?></p>
+                <?php else : ?>
+                    <?php if (!empty($direct_granted_caps)) : ?>
+                        <h3 class="ppc-user-cap-section-title"><?php esc_html_e('Granted', 'capability-manager-enhanced'); ?></h3>
+                        <ul class="ppc-user-cap-list">
+                            <?php foreach ($direct_granted_caps as $capability) : ?>
+                                <li><code><?php echo esc_html($capability); ?></code></li>
+                            <?php endforeach; ?>
+                        </ul>
+                    <?php endif; ?>
+
+                    <?php if (!empty($direct_denied_caps)) : ?>
+                        <h3 class="ppc-user-cap-section-title"><?php esc_html_e('Denied', 'capability-manager-enhanced'); ?></h3>
+                        <ul class="ppc-user-cap-list">
+                            <?php foreach ($direct_denied_caps as $capability) : ?>
+                                <li><code><?php echo esc_html($capability); ?></code></li>
+                            <?php endforeach; ?>
+                        </ul>
+                    <?php endif; ?>
+                <?php endif; ?>
+            </div>
+        </div>
+    </div>
+</div>

--- a/includes/user-capabilities-view.php
+++ b/includes/user-capabilities-view.php
@@ -82,11 +82,29 @@ if (!defined('ABSPATH')) {
                 <?php if (empty($effective_granted_caps)) : ?>
                     <p><?php esc_html_e('This user has no granted capabilities.', 'capability-manager-enhanced'); ?></p>
                 <?php else : ?>
-                    <ul class="ppc-user-cap-list">
+                    <label class="screen-reader-text" for="ppc-granted-capability-search">
+                        <?php esc_html_e('Search granted capabilities', 'capability-manager-enhanced'); ?>
+                    </label>
+                    <input
+                        type="search"
+                        id="ppc-granted-capability-search"
+                        class="regular-text ppc-user-capability-search"
+                        placeholder="<?php esc_attr_e('Search granted capabilities...', 'capability-manager-enhanced'); ?>"
+                        autocomplete="off"
+                        aria-controls="ppc-granted-capability-list"
+                        aria-describedby="ppc-granted-capability-search-description"
+                    />
+                    <p id="ppc-granted-capability-search-description" class="description ppc-user-capability-search-description">
+                        <?php esc_html_e('Type to filter this capability list.', 'capability-manager-enhanced'); ?>
+                    </p>
+                    <ul id="ppc-granted-capability-list" class="ppc-user-cap-list">
                         <?php foreach ($effective_granted_caps as $capability) : ?>
-                            <li><code><?php echo esc_html($capability); ?></code></li>
+                            <li data-ppc-capability-search="<?php echo esc_attr($capability); ?>"><code><?php echo esc_html($capability); ?></code></li>
                         <?php endforeach; ?>
                     </ul>
+                    <p id="ppc-granted-capability-no-results" class="ppc-user-capability-search-no-results" role="status" aria-live="polite" hidden>
+                        <?php esc_html_e('No granted capabilities match your search.', 'capability-manager-enhanced'); ?>
+                    </p>
                 <?php endif; ?>
             </div>
         </div>

--- a/includes/user-capabilities-view.php
+++ b/includes/user-capabilities-view.php
@@ -106,16 +106,14 @@ if (!defined('ABSPATH')) {
             </div>
         <?php endif; ?>
 
-        <div class="postbox">
-            <div class="postbox-header">
-                <h2><?php esc_html_e('Direct User Overrides', 'capability-manager-enhanced'); ?></h2>
-            </div>
-            <div class="inside">
-                <p class="ppc-user-cap-note"><?php esc_html_e('These entries are stored directly on the user account instead of coming from a role.', 'capability-manager-enhanced'); ?></p>
+        <?php if (!empty($direct_granted_caps) || !empty($direct_denied_caps)) : ?>
+            <div class="postbox">
+                <div class="postbox-header">
+                    <h2><?php esc_html_e('Direct User Overrides', 'capability-manager-enhanced'); ?></h2>
+                </div>
+                <div class="inside">
+                    <p class="ppc-user-cap-note"><?php esc_html_e('These entries are stored directly on the user account instead of coming from a role.', 'capability-manager-enhanced'); ?></p>
 
-                <?php if (empty($direct_granted_caps) && empty($direct_denied_caps)) : ?>
-                    <p><?php esc_html_e('This user has no direct capability overrides.', 'capability-manager-enhanced'); ?></p>
-                <?php else : ?>
                     <?php if (!empty($direct_granted_caps)) : ?>
                         <h3 class="ppc-user-cap-section-title"><?php esc_html_e('Granted', 'capability-manager-enhanced'); ?></h3>
                         <ul class="ppc-user-cap-list">
@@ -133,9 +131,9 @@ if (!defined('ABSPATH')) {
                             <?php endforeach; ?>
                         </ul>
                     <?php endif; ?>
-                <?php endif; ?>
+                </div>
             </div>
-        </div>
+        <?php endif; ?>
 
         <?php if (!empty($publishpress_permissions['available'])) : ?>
             <div class="postbox">


### PR DESCRIPTION
## Summary
- add a Capabilities action to each editable user row and the user profile screen
- add a read-only User Capabilities page listing assigned roles and effective capabilities
- surface direct user-specific capability overrides separately from role-derived capabilities

## Validation
- PHP syntax checks passed
- git diff --check passed
- Browser/WordPress runtime was not available in this environment

This is the free-repository implementation of the requested user capabilities view.